### PR TITLE
Implement indication of iteration with lowest loss

### DIFF
--- a/doc/recipes/docs/basics/firsttrain.rst
+++ b/doc/recipes/docs/basics/firsttrain.rst
@@ -389,3 +389,17 @@ training process or for predictions based on the resulting network potential.
 
 In fact, the relevant output ``fnetout.xml`` is only created in validation or
 prediction mode and introduced in the :ref:`next section <sec-firstpredict>`.
+
+If the total trajectory of the loss function and total gradient is of interest,
+it can be written out as ``iterout.dat`` by setting the corresponding entry
+(default: No)::
+
+  Options {
+       .
+       .
+       .
+    WriteIterationTrajectory = Yes
+  }
+
+The column order of the output in ``iterout.dat`` is analogous to the standard
+output.

--- a/prog/fortnet/lib_fortnet/initprogram.F90
+++ b/prog/fortnet/lib_fortnet/initprogram.F90
@@ -58,7 +58,7 @@ module fnet_initprogram
 
   public :: TProgramVariables, TProgramVariables_init
   public :: TFeatures, TFeatures_init, TFeatures_collect
-  public :: TArch, TData, TEnv, TExternal
+  public :: TArch, TData, TEnv, TExternal, TOption
   public :: initOptimizer, readAcsfFromFile
 
 
@@ -322,6 +322,9 @@ module fnet_initprogram
 
     !> wether to resume from existing netstat files on disk
     logical :: tReadNetStats
+
+    !> wether to write loss and gradients for all training iterations to disk
+    logical :: tWriteIterTraj
 
     !> mode of current run (train, validate, predict)
     character(len=:), allocatable :: mode
@@ -966,6 +969,8 @@ contains
     real(dp) :: tmpRealSeed
 
     call getChildValue(node, 'ReadNetStats', this%option%tReadNetStats, .false.)
+
+    call getChildValue(node, 'WriteIterationTrajectory', this%option%tWriteIterTraj, .false.)
 
     call getChildValue(node, 'Mode', strBuffer)
     this%option%mode = tolower(unquote(char(strBuffer)))

--- a/prog/fortnet/lib_io/CMakeLists.txt
+++ b/prog/fortnet/lib_io/CMakeLists.txt
@@ -3,6 +3,7 @@ set(curdir "lib_io")
 set(sources-fpp
   ${curdir}/fnetdata.F90
   ${curdir}/fnetout.F90
+  ${curdir}/iterout.F90
   ${curdir}/precond.F90)
 
 set(ALL-SOURCES-FPP ${ALL-SOURCES-FPP} ${sources-fpp} PARENT_SCOPE)

--- a/prog/fortnet/lib_io/iterout.F90
+++ b/prog/fortnet/lib_io/iterout.F90
@@ -1,0 +1,105 @@
+!--------------------------------------------------------------------------------------------------!
+!  FORTNET: A Behler-Parrinello-Neural-Network Implementation                                      !
+!  Copyright (C) 2020 - 2021  T. W. van der Heide                                                  !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+module fnet_iterout
+
+  ! use dftbp_xmlf90
+  ! use dftbp_hsdutils, only : writeChildValue
+  use dftbp_message, only : error
+  use dftbp_accuracy, only: dp
+  ! use dftbp_charmanip, only : i2c
+
+  ! use fnet_nestedtypes, only : TRealArray2D, TPredicts
+
+  implicit none
+
+  private
+
+  public :: writeIterTrajToFile
+
+
+contains
+
+  !> Write obtained results to fnetout.xml file
+  subroutine writeIterTrajToFile(fname, loss, validLoss, gradients)
+
+    !> filename (will be iterout.dat)
+    character(len=*), intent(in) :: fname
+
+    !> loss trajectory during training
+    real(dp), intent(in), optional, target :: loss(:)
+
+    !> validation loss trajectory during training
+    real(dp), intent(in), optional, target :: validLoss(:)
+
+    !> gradient trajectory during training
+    real(dp), intent(in), optional, target :: gradients(:)
+
+    !> pointer holding the available data
+    real(dp), pointer :: pData(:,:)
+
+    !> unique fileunit
+    integer :: fd
+
+    !> auxiliary variables
+    integer :: iLine, nLines, nColumns
+
+    if (present(loss)) then
+      nLines = size(loss)
+    elseif (present(validLoss)) then
+      nLines = size(validLoss)
+    elseif (present(gradients)) then
+      nLines = size(gradients)
+    else
+      call error('Empty list of entries obtained. Provide at least one array with data.')
+    end if
+
+    nColumns = 0
+    allocate(pData(nColumns, nLines))
+
+    if (present(loss)) then
+      nColumns = nColumns + 1
+    end if
+
+    if (present(validLoss)) then
+      nColumns = nColumns + 1
+    end if
+
+    if (present(gradients)) then
+      nColumns = nColumns + 1
+    end if
+
+    allocate(pData(nColumns, nLines))
+    nColumns = 1
+
+    if (present(loss)) then
+      pData(nColumns, 1:nLines) = loss
+      nColumns = nColumns + 1
+    end if
+
+    if (present(gradients)) then
+      pData(nColumns, 1:nLines) = gradients
+      nColumns = nColumns + 1
+    end if
+
+    if (present(validLoss)) then
+      pData(nColumns, 1:nLines) = validLoss
+    end if
+
+    open(newunit=fd, file=fname, form='formatted', status='replace', action='write')
+
+    do iLine = 1, nLines
+      write(fd, '(I0,3ES26.16E3)') iLine, pData(:, iLine)
+    end do
+
+    close(fd)
+
+  end subroutine writeIterTrajToFile
+
+end module fnet_iterout

--- a/prog/fortnet/lib_io/iterout.F90
+++ b/prog/fortnet/lib_io/iterout.F90
@@ -13,7 +13,7 @@ module fnet_iterout
   ! use dftbp_hsdutils, only : writeChildValue
   use dftbp_message, only : error
   use dftbp_accuracy, only: dp
-  ! use dftbp_charmanip, only : i2c
+  use dftbp_charmanip, only : i2c
 
   ! use fnet_nestedtypes, only : TRealArray2D, TPredicts
 
@@ -43,6 +43,9 @@ contains
 
     !> pointer holding the available data
     real(dp), pointer :: pData(:,:)
+
+    !> formatting of output file
+    character(len=:), allocatable :: fmt
 
     !> unique fileunit
     integer :: fd
@@ -94,8 +97,10 @@ contains
 
     open(newunit=fd, file=fname, form='formatted', status='replace', action='write')
 
+    fmt = '(I' // i2c(len(i2c(nLines))) // ',3ES26.16E3)'
+
     do iLine = 1, nLines
-      write(fd, '(I0,3ES26.16E3)') iLine, pData(:, iLine)
+      write(fd, fmt) iLine, pData(:, iLine)
     end do
 
     close(fd)

--- a/prog/fortnet/prg_fnet/fortnet.F90
+++ b/prog/fortnet/prg_fnet/fortnet.F90
@@ -23,12 +23,13 @@ program fortnet
 
   use fnet_initprogram, only : TProgramVariables, TProgramVariables_init, TArch, TData, TEnv
   use fnet_initprogram, only : initOptimizer, readAcsfFromFile, TExternal
-  use fnet_initprogram, only : TFeatures, TFeatures_init, TFeatures_collect
+  use fnet_initprogram, only : TFeatures, TFeatures_init, TFeatures_collect, TOption
   use fnet_nestedtypes, only : TEnv_init, TPredicts
   use fnet_acsf, only : TAcsf, TAcsf_init, TAcsfParams_init
   use fnet_bpnn, only : TBpnn, TBpnn_init
   use fnet_loss, only : minError, maxError, msLoss, rmsLoss, maLoss
   use fnet_fnetout, only : writeFnetout
+  use fnet_iterout, only : writeIterTrajToFile
 
   implicit none
 
@@ -50,6 +51,9 @@ program fortnet
 
   !> file name of generic Fortnet fortout.xml file
   character(len=*), parameter :: fnetoutFile = 'fnetout.xml'
+
+  !> file name of generic Fortnet iterout.dat file
+  character(len=*), parameter :: iteroutFile = 'iterout.dat'
 
   !> initialise global environment
   call initGlobalEnv()
@@ -77,7 +81,7 @@ program fortnet
     call prog%acsf%toFile(acsfFile, prog%data%globalSpNames)
   end if
 
-  call runCore(prog%option%mode, prog%ext, prog%data, bpnn, prog%features, prog%acsf,&
+  call runCore(prog%option, prog%ext, prog%data, bpnn, prog%features, prog%acsf,&
       & prog%validAcsf, prog%train%lossType, prog%env, predicts)
 
   if (tLead .and. (prog%option%mode == 'validate' .or. prog%option%mode == 'predict')) then
@@ -280,10 +284,10 @@ contains
   end subroutine calculateMappings
 
 
-  subroutine runCore(mode, ext, data, bpnn, features, acsf, validAcsf, lossType, env, predicts)
+  subroutine runCore(option, ext, data, bpnn, features, acsf, validAcsf, lossType, env, predicts)
 
-    !> mode of current run (train, validate, run)
-    character(len=*), intent(in) :: mode
+    !> representation of option informations
+    type(TOption), intent(in) :: option
 
     !> representation of external informations
     type(TExternal), intent(inout) :: ext
@@ -327,6 +331,9 @@ contains
     !> training/validation loss obtained during training
     real(dp), allocatable :: loss(:), validLoss(:)
 
+    !> training gradients obtained during training
+    real(dp), allocatable :: gradients(:)
+
     !> summed loss of predictions, in comparison to targets
     real(dp) :: mse, rms, mae
 
@@ -367,7 +374,7 @@ contains
       end if
     end if
 
-    select case(mode)
+    select case(option%mode)
     case ('train')
       write(stdOut, '(A,/)') 'Starting training...'
       if (data%tMonitorValid) then
@@ -377,10 +384,11 @@ contains
         write(stdOut, '(A11,6X,A13,6X,A13)') 'iTrain', toupper(lossType) // '-Loss', 'Gradients'
       end if
       write(stdout, '(A)') repeat('-', 68)
-      if (data%tMonitorValid) then
-        call bpnn%nTrain(prog, tConverged, loss=loss, validLoss=validLoss)
-      else
-        call bpnn%nTrain(prog, tConverged, loss=loss)
+      call bpnn%nTrain(prog, tConverged, loss=loss, validLoss=validLoss, gradients=gradients)
+      if (option%tWriteIterTraj .and. data%tMonitorValid) then
+        call writeIterTrajToFile(iteroutFile, loss=loss, validLoss=validLoss, gradients=gradients)
+      elseif (option%tWriteIterTraj .and. (.not. data%tMonitorValid)) then
+        call writeIterTrajToFile(iteroutFile, loss=loss, gradients=gradients)
       end if
       write(stdout, '(A,/)') repeat('-', 68)
       if (tConverged) then
@@ -388,7 +396,7 @@ contains
       else
         write(stdOut, '(A,/)') 'Training finished (max. Iterations reached)'
       end if
-      write(stdout, '(A,/)') repeat('=', 68)
+      write(stdout, '(A,/)') repeat('-', 68)
       write(stdOut, '(A,/)') 'Loss Analysis (global min.)'
       iMin = minloc(loss, dim=1)
       write(stdOut, '(A,I0,A,(ES12.6E2))') 'iTrain: ', iMin, ', Loss: ', loss(iMin)


### PR DESCRIPTION
An option is added to allow the user to write out the entire loss and gradient trajectory. This is done in plain text format so that the corresponding file can be read directly into an array (further closes #16 ).