### PR TITLE
Increase the HDF5 version for Intel regression testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,9 +132,9 @@ jobs:
     - name: Install HDF5
       if: contains(matrix.os, 'ubuntu')
       run: |
-        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.1/src/CMake-hdf5-1.12.1.tar.gz
-        tar xfz CMake-hdf5-1.12.1.tar.gz
-        cd CMake-hdf5-1.12.1/hdf5-1.12.1/
+        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-1.13.0/src/CMake-hdf5-1.13.0.tar.gz
+        tar xfz CMake-hdf5-1.13.0.tar.gz
+        cd CMake-hdf5-1.13.0/hdf5-1.13.0/
         CC=gcc CXX=icpc FC=ifort F9X=ifort ./configure --prefix=${PWD}/hdf5 --enable-fortran --with-default-api-version=v110 --enable-shared
         make -j -l2
         make install


### PR DESCRIPTION
Bumps HDF5 release version of Intel regression tests from 1.12.1 to 1.13.0.