### PR TITLE
Link against LAPACK/BLAS for fast matrix contraction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
       WITH_MPI: false
       APT_PACKAGES: >-
         intel-oneapi-compiler-fortran
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         intel-oneapi-mkl
         intel-oneapi-mkl-devel
       CMAKE_OPTIONS: >-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ include(FortnetUtils)
 fnet_ensure_out_of_source_build()
 fnet_load_build_settings()
 
-set(FORTNET_VERSION "0.2")
+set(FORTNET_VERSION "0.6")
 
-project(fortnet VERSION ${FORTNET_VERSION} LANGUAGES Fortran)
+project(fortnet VERSION ${FORTNET_VERSION} LANGUAGES Fortran C)
 
 fnet_setup_build_type()
 fnet_load_toolchain_settings()
@@ -71,9 +71,12 @@ include(GNUInstallDirs)
 if(WITH_MPI)
   set(MPIFX_GIT_REPOSITORY "https://github.com/dftbplus/mpifx.git")
   set(MPIFX_GIT_TAG "0cb07ee08cbb20f3f7bb2527152a4ec317c579ad")  # do not change manually!
-  fnet_config_hybrid_dependency(MpiFx MpiFx::MpiFx "${HYBRID_CONFIG_METHODS}" "QUIET" 
+  fnet_config_hybrid_dependency(MpiFx MpiFx::MpiFx "${HYBRID_CONFIG_METHODS}" "QUIET"
     external/mpifx "${exclude}" "${MPIFX_GIT_REPOSITORY}" "${MPIFX_GIT_TAG}")
 endif()
+
+find_package(CustomBlas REQUIRED)
+find_package(CustomLapack REQUIRED)
 
 add_subdirectory(external/xmlf90 EXCLUDE_FROM_ALL)
 

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,11 @@ software via Python's ``pip`` command::
 
   pip install cmake h5py
 
-Start CMake by passing your compiler as environment variable ``FC`` and the
-location where the code should be installed and the build directory
+Start CMake by passing your compilers environment variables ``FC``, ``CC`` and
+the location where the code should be installed and the build directory
 (``_build``) as options::
 
-  FC=mpifort cmake -DCMAKE_INSTALL_PREFIX=$HOME/opt/fnet -B _build .
+  FC=mpifort CC=gcc cmake -DCMAKE_INSTALL_PREFIX=$HOME/opt/fnet -B _build .
 
 If the configuration was successful, start the build with::
 

--- a/cmake/FortnetUtils.cmake
+++ b/cmake/FortnetUtils.cmake
@@ -368,14 +368,14 @@ endfunction()
 # Variables:
 #     <UPPER_PACKAGE_NAME>_SOURCE_DIR, <UPPER_PACKAGE_NAME>_BINARY_DIR:
 #         Source and binary directories for the build (to pass to add_subdirectory())
-# 
+#
 macro(fnet_config_hybrid_dependency package target config_methods findpkgopts subdir subdiropts
     git_repository git_tag)
 
   set(_allowed_methods "submodule;find;fetch")
   string(TOLOWER "${package}" _package_lower)
   string(TOUPPER "${package}" _package_upper)
-  
+
   foreach(_config_method IN ITEMS ${config_methods})
 
     string(TOLOWER "${_config_method}" _config_lower)
@@ -395,7 +395,7 @@ macro(fnet_config_hybrid_dependency package target config_methods findpkgopts su
       endif()
 
     elseif("${_config_lower}" STREQUAL "submodule")
-      
+
       if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/origin/CMakeLists.txt
           AND GIT_WORKING_COPY)
         message(STATUS "${package}: Downloading via git submodule update")

--- a/cmake/Modules/FindCustomBlas.cmake
+++ b/cmake/Modules/FindCustomBlas.cmake
@@ -1,0 +1,126 @@
+# Distributed under the OSI-approved BSD 2-Clause License.
+#
+# Copyright (C) 2021 DFTB+ developers group
+#
+
+#[=======================================================================[.rst:
+FindCustomBlas
+----------------
+
+Finds the BLAS library
+
+This is a wrapper around CMakes FindBLAS module with the additional
+possibility to customize the library name manually. In latter case the module will
+check the existence of those libraries and stop if they are not found.
+
+Note: The module is named FindBlas (and not FindBLAS) to avoid name
+collision with CMakes built-in FindBLAS module.
+
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target, if found:
+
+``BLAS::BLAS``
+  The BLAS library
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will define the following variable:
+
+``BLAS_FOUND``
+  True if the system has the BLAS library
+
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may be set to influence the library detection:
+
+``BLAS_DETECTION``
+  Whether BLAS libraries should be detected (default: True). If set to False,
+  the settings in ``BLAS_LIBRARY`` will be used without any further checks.
+
+``BLAS_LIBRARY``
+  Customized BLAS library/libraries to use (instead of autodetected ones).  If
+  no BLAS library is required (e.g. the linker automatically links it) set
+  ``BLAS_LIBRARY="NONE"``. If not set or empty, the built-in BLAS finder
+  (the findBLAS module) will be invoked. Otherwise, the listed libraries
+  will be checked for existence (unless disabled in ``BLAS_DETECTION``) and
+  the variable is overwritten to contain the libraries with their with full
+  path.
+
+``BLAS_LIBRARY_DIR``
+  Directories which should be looked up in order to find the customized libraries.
+
+``BLAS_LINKER_FLAG``
+  Flags to use when linking BLAS
+
+Additionally, the cache variables of the built-in FindBLAS modules may used to
+influence the BLAS detection if the built-in module is invoked.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+include(CustomLibraryFinder)
+
+if(TARGET BLAS::BLAS)
+
+  set(CUSTOMBLAS_FOUND True)
+  set(CustomBlas_FOUND True)
+  set(BLAS_FOUND True)
+  set(Blas_FOUND True)
+
+else()
+
+  option(BLAS_DETECTION "Whether BLAS library should be detected" TRUE)
+
+  if(BLAS_DETECTION)
+    # BLAS has either not been found yet or it was found by an older built-in findBLAS module.
+    # which does not provide the imported target BLAS::BLAS
+
+    if("${BLAS_LIBRARY}" STREQUAL "")
+
+      # No user customized BLAS library, try built-in finder
+      if(NOT BLAS_FOUND)
+        find_package(BLAS)
+      endif()
+      set(BLAS_LIBRARY "${BLAS_LIBRARIES}" CACHE STRING "BLAS library to link" FORCE)
+      set(BLAS_LINKER_FLAG "${BLAS_LINKER_FLAGS}" CACHE STRING
+        "Linker flags to use when linking BLAS" FORCE)
+
+    elseif(NOT "${BLAS_LIBRARY}" STREQUAL "NONE")
+
+      # BLAS explicitely set by the user, search for those libraries
+      find_custom_libraries("${BLAS_LIBRARY}" "${BLAS_LIBRARY_DIR}"
+        "${CustomBlas_FIND_QUIETLY}" _libs)
+      set(BLAS_LIBRARY "${_libs}" CACHE STRING "List of BLAS libraries to link" FORCE)
+      unset(_libs)
+
+    endif()
+
+    set(BLAS_DETECTION False CACHE BOOL "Whether BLAS libraries should be detected" FORCE)
+
+  endif()
+
+  find_package_handle_standard_args(CustomBlas REQUIRED_VARS BLAS_LIBRARY)
+
+  set(BLAS_FOUND ${CUSTOMBLAS_FOUND})
+  set(Blas_FOUND ${CUSTOMBLAS_FOUND})
+
+  if (BLAS_FOUND AND NOT TARGET BLAS::BLAS)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    if(NOT "${BLAS_LIBRARY}" STREQUAL "NONE")
+      target_link_libraries(BLAS::BLAS INTERFACE "${BLAS_LIBRARY}")
+    endif()
+    if(NOT "${BLAS_LINKER_FLAG}" STREQUAL "")
+      target_link_options(BLAS::BLAS INTERFACE "${BLAS_LINKER_FLAG}")
+    endif()
+  endif()
+
+  mark_as_advanced(BLAS_DETECTION BLAS_LIBRARY BLAS_LIBRARY_DIR BLAS_LINKER_FLAG)
+
+endif()

--- a/cmake/Modules/FindCustomLapack.cmake
+++ b/cmake/Modules/FindCustomLapack.cmake
@@ -1,0 +1,129 @@
+# Distributed under the OSI-approved BSD 2-Clause License.
+#
+# Copyright (C) 2021 DFTB+ developers group
+#
+
+#[=======================================================================[.rst:
+FindCustomLapack
+----------------
+
+Finds the LAPACK library
+
+This is a wrapper around CMakes FindLAPACK module with the additional
+possibility to customize the library name manually. In latter case the module will
+check the existence of those libraries and stop if they are not found.
+
+Note: The module is named FindLapack (and not FindLAPACK) to avoid name
+collision with CMakes built-in FindLAPACK module.
+
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target, if found:
+
+``LAPACK::LAPACK``
+  The LAPACK library
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will define the following variable:
+
+``LAPACK_FOUND``
+  True if the system has the LAPACK library
+
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may be set to influence the library detection:
+
+``LAPACK_DETECTION``
+  Whether LAPACK libraries should be detected (default: True). If set to False,
+  the settings in ``LAPACK_LIBRARY`` will be used without any further checks.
+
+``LAPACK_LIBRARY``
+  Customized LAPACK library/libraries to use (instead of autodetected ones).  If
+  no LAPACK library is required (e.g. the linker automatically links it) set
+  ``LAPACK_LIBRARY="NONE"``. If not set or empty, the built-in LAPACK finder
+  (the findLAPACK module) will be invoked. Otherwise, the listed libraries
+  will be checked for existence (unless disabled in ``LAPACK_DETECTION``) and
+  the variable is overwritten to contain the libraries with their with full
+  path.
+
+``LAPACK_LIBRARY_DIR``
+  Directories which should be looked up in order to find the customized libraries.
+
+``LAPACK_LINKER_FLAG``
+  Flags to use when linking LAPACK
+
+Additionally, the cache variables of the built-in FindLAPACK modules may used to
+influence the LAPACK detection if the built-in module is invoked.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+include(CustomLibraryFinder)
+
+if(TARGET LAPACK::LAPACK)
+
+  set(CUSTOMLAPACK_FOUND True)
+  set(CustomLapack_FOUND True)
+  set(LAPACK_FOUND True)
+  set(Lapack_FOUND True)
+
+else()
+
+  option(LAPACK_DETECTION "Whether LAPACK library should be detected" TRUE)
+
+  if(LAPACK_DETECTION)
+    # LAPACK has either not been found yet or it was found by an older built-in findLAPACK module.
+    # which does not provide the imported target LAPACK::LAPACK
+
+    if("${LAPACK_LIBRARY}" STREQUAL "")
+
+      # No user customized LAPACK library, try built-in finder
+      if(NOT LAPACK_FOUND)
+        find_package(LAPACK)
+      endif()
+      set(LAPACK_LIBRARY "${LAPACK_LIBRARIES}" CACHE STRING "LAPACK library to link" FORCE)
+      set(LAPACK_LINKER_FLAG "${LAPACK_LINKER_FLAGS}" CACHE STRING
+        "Linker flags to use when linking LAPACK" FORCE)
+
+    elseif(NOT "${LAPACK_LIBRARY}" STREQUAL "NONE")
+
+      # LAPACK explicitely set by the user, search for those libraries
+      find_custom_libraries("${LAPACK_LIBRARY}" "${LAPACK_LIBRARY_DIR}"
+        "${CustomLapack_FIND_QUIETLY}" _libs)
+      set(LAPACK_LIBRARY "${_libs}" CACHE STRING "List of LAPACK libraries to link" FORCE)
+      unset(_libs)
+
+    endif()
+
+    set(LAPACK_DETECTION False CACHE BOOL "Whether LAPACK libraries should be detected" FORCE)
+
+  endif()
+
+  find_package_handle_standard_args(CustomLapack REQUIRED_VARS LAPACK_LIBRARY)
+
+  set(LAPACK_FOUND ${CUSTOMLAPACK_FOUND})
+  set(Lapack_FOUND ${CUSTOMLAPACK_FOUND})
+
+  if (LAPACK_FOUND AND NOT TARGET LAPACK::LAPACK)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
+    if(NOT "${LAPACK_LIBRARY}" STREQUAL "NONE")
+      target_link_libraries(LAPACK::LAPACK INTERFACE "${LAPACK_LIBRARY}")
+    endif()
+    if(NOT "${LAPACK_LINKER_FLAG}" STREQUAL "")
+      target_link_options(LAPACK::LAPACK INTERFACE "${LAPACK_LINKER_FLAG}")
+    endif()
+    if(TARGET BLAS::BLAS)
+      target_link_libraries(LAPACK::LAPACK INTERFACE BLAS::BLAS)
+    endif()
+  endif()
+
+  mark_as_advanced(LAPACK_DETECTION LAPACK_LIBRARY LAPACK_LIBRARY_DIR LAPACK_LINKER_FLAG)
+
+endif()

--- a/prog/fortnet/CMakeLists.txt
+++ b/prog/fortnet/CMakeLists.txt
@@ -50,6 +50,8 @@ if(WITH_MPI)
   target_link_libraries(fortnet PUBLIC MpiFx::MpiFx)
 endif()
 
+target_link_libraries(fortnet PUBLIC LAPACK::LAPACK)
+
 # cmake 3.19.x and 3.20.x feature broken targets :(
 # target_link_libraries(fortnet PUBLIC hdf5::hdf5_hl_fortran hdf5::hdf5_fortran)
 

--- a/prog/fortnet/lib_dftbp/CMakeLists.txt
+++ b/prog/fortnet/lib_dftbp/CMakeLists.txt
@@ -3,6 +3,8 @@ set(curdir "lib_dftbp")
 set(sources-fpp
   ${curdir}/accuracy.F90
   ${curdir}/assert.F90
+  ${curdir}/blas.F90
+  ${curdir}/blasroutines.F90
   ${curdir}/charmanip.F90
   ${curdir}/conjgrad.F90
   ${curdir}/constants.F90

--- a/prog/fortnet/lib_dftbp/blas.F90
+++ b/prog/fortnet/lib_dftbp/blas.F90
@@ -1,0 +1,205 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#! Note: This module contains preprocessor variable substitutions in subroutine names (${NAME}$)
+#! which may break the documentation system. Make sure you preprocess this file before passing it
+#! to a source code documentation tool.
+
+#:include 'common.fypp'
+
+!> Interface wrapper for the blas routines.
+!>
+!> ALL BLAS routines which are called from the main code must be included here.
+module dftbp_extlibs_blas
+
+  use dftbp_accuracy, only : rsp, rdp
+
+  public
+
+
+  interface
+
+    !> performs one of the matrix-vector operations
+    !> y := alpha*A*x + beta*y, or y := alpha*A**T*x + beta*y,
+    subroutine sgemv(trans, mm, nn, alpha, aa, lda, xx, incx, beta, yy, incy)
+      import rsp
+
+      !> should transposition be used
+      character, intent(in) :: trans
+
+      !> matrix sizing
+      integer, intent(in) :: mm
+
+      !> matrix  size
+      integer, intent(in) :: nn
+
+      !> scaling factor
+      real(rsp), intent(in) :: alpha
+
+      !> leading matrix dimension
+      integer, intent(in) :: lda
+
+      !> matrix A
+      real(rsp), intent(in) :: aa(lda, *)
+
+      !> vector
+      real(rsp), intent(in) :: xx(*)
+
+      !> stride
+      integer, intent(in) :: incx
+
+      !> scale factor
+      real(rsp), intent(in) :: beta
+
+      !> vector
+      real(rsp), intent(inout) :: yy(*)
+
+      !> stride
+      integer, intent(in) :: incy
+    end subroutine sgemv
+
+
+    !> performs one of the matrix-vector operations
+    !> y := alpha*A*x + beta*y, or y := alpha*A**T*x + beta*y,
+    subroutine dgemv(trans, mm, nn, alpha, aa, lda, xx, incx, beta, yy, incy)
+      import rdp
+
+      !> should transposition be used
+      character, intent(in) :: trans
+
+      !> matrix sizing
+      integer, intent(in) :: mm
+
+      !> matrix  size
+      integer, intent(in) :: nn
+
+      !> scale factor
+      real(rdp), intent(in) :: alpha
+
+      !> leading matrix dimension
+      integer, intent(in) :: lda
+
+      !> matrix A
+      real(rdp), intent(in) :: aa(lda, *)
+
+      !> vector
+      real(rdp), intent(in) :: xx(*)
+
+      !> stride
+      integer, intent(in) :: incx
+
+      !> scaling factor
+      real(rdp), intent(in) :: beta
+
+      !> vector
+      real(rdp), intent(inout) :: yy(*)
+
+      !> stride
+      integer, intent(in) :: incy
+    end subroutine dgemv
+
+
+    !> performs one of the matrix-matrix operations
+    !> C := alpha*op( A )*op( B ) + beta*C, where  op( X ) is one of
+    !> op( X ) = X, or op( X ) = X**T
+    subroutine sgemm(transa, transb, mm, nn, kk, alpha, aa, lda, bb, ldb, beta,&
+        & cc, ldc)
+      import rsp
+
+      !> On entry, TRANSA specifies the form of op( A ) to be used
+      character, intent(in) :: transa
+
+      !> on entry specifies op(B)
+      !> should transposition be used
+      character, intent(in) :: transb
+
+      !> matrix sizing
+      integer, intent(in) :: mm
+
+      !> matrix  size
+      integer, intent(in) :: nn
+
+      !> shared index size
+      integer, intent(in) :: kk
+
+      !> scaling factor
+      real(rsp), intent(in) :: alpha
+
+      !> leading matrix dimension
+      integer, intent(in) :: lda
+
+      !> matrix A
+      real(rsp), intent(in) :: aa(lda, *)
+
+      !> leading matrix dimension
+      integer, intent(in) :: ldb
+
+      !> matrix B
+      real(rsp), intent(in) :: bb(ldb, *)
+
+      !> scale factor
+      real(rsp), intent(in) :: beta
+
+      !> leading matrix dimension
+      integer, intent(in) :: ldc
+
+      !> matrix C
+      real(rsp), intent(inout) :: cc(ldc, *)
+    end subroutine sgemm
+
+
+    !> performs one of the matrix-matrix operations
+    !> C := alpha*op( A )*op( B ) + beta*C, where  op( X ) is one of
+    !> op( X ) = X, or op( X ) = X**T
+    subroutine dgemm(transa, transb, mm, nn, kk, alpha, aa, lda, bb, ldb, beta,&
+        & cc, ldc)
+      import rdp
+
+      !> On entry, TRANSA specifies the form of op( A ) to be used
+      character, intent(in) :: transa
+
+      !> on entry specifies op(B)
+      !> should transposition be used
+      character, intent(in) :: transb
+
+      !> matrix sizing
+      integer, intent(in) :: mm
+
+      !> matrix  size
+      integer, intent(in) :: nn
+
+      !> shared index size
+      integer, intent(in) :: kk
+
+      !> scale factor
+      real(rdp), intent(in) :: alpha
+
+      !> leading matrix dimension
+      integer, intent(in) :: lda
+
+      !> matrix A
+      real(rdp), intent(in) :: aa(lda, *)
+
+      !> leading matrix dimension
+      integer, intent(in) :: ldb
+
+      !> matrix B
+      real(rdp), intent(in) :: bb(ldb, *)
+
+      !> scaling factor
+      real(rdp), intent(in) :: beta
+
+      !> leading matrix dimension
+      integer, intent(in) :: ldc
+
+      !> matrix C
+      real(rdp), intent(inout) :: cc(ldc, *)
+    end subroutine dgemm
+
+  end interface
+
+end module dftbp_extlibs_blas

--- a/prog/fortnet/lib_dftbp/blasroutines.F90
+++ b/prog/fortnet/lib_dftbp/blasroutines.F90
@@ -1,0 +1,401 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+#! suffix and kinds for real types
+#:set REAL_KIND_PARAMS = [('real', 's'), ('dble', 'd')]
+
+!> Contains F90 wrapper functions for some commonly used blas calls needed in the code. The
+!> interface of all BLAS calls must be defined in the module blas.
+module dftbp_math_blasroutines
+
+  use dftbp_assert
+  use dftbp_accuracy, only : dp, rsp, rdp
+
+  implicit none
+  private
+
+  public ::  gemv, gemm
+
+
+  !> General matrix vector multiply y := alpha*a*x + beta*y
+  !> Wrapper for the level 2 blas routine
+  interface gemv
+    module procedure gemv_real
+    module procedure gemv_dble
+    #:for suffix, _ in REAL_KIND_PARAMS
+      module procedure gemv231_${suffix}$
+    #:endfor
+    #:for suffix, _ in REAL_KIND_PARAMS
+      module procedure gemv242_${suffix}$
+    #:endfor
+  end interface gemv
+
+
+  !> Interface to GEMM routines evaluates C := alpha*op( A )*op( B ) + beta*C, where op( X ) is one
+  !> of op( X ) = X or op( X ) = X'
+
+  !> Wrapper for the level 3 blas routine
+  interface gemm
+    module procedure gemm_real
+    module procedure gemm_dble
+    #:for SUFFIX, _ in REAL_KIND_PARAMS
+      module procedure gemm332_${SUFFIX}$
+    #:endfor
+  end interface gemm
+
+
+contains
+
+  !> real matrix*vector product
+  subroutine gemv_real(y,a,x,alpha,beta,trans)
+
+    !> vector
+    real(rsp), intent(inout) :: y(:)
+
+    !> matrix
+    real(rsp), intent(in) :: a(:,:)
+
+    !> vector
+    real(rsp), intent(in) :: x(:)
+
+    !> optional scaling factor (defaults to 1)
+    real(rsp), intent(in), optional :: alpha
+
+    !> optional scaling factor (defaults to 0)
+    real(rsp), intent(in), optional :: beta
+
+    !> optional transpose (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c' and 'C'
+    character, intent(in), optional :: trans
+
+    integer :: n, m
+    character :: iTrans
+    real(rsp) :: iAlpha, iBeta
+
+    if (present(trans)) then
+      iTrans = trans
+    else
+      iTrans = 'n'
+    end if
+    if (present(alpha)) then
+      iAlpha = alpha
+    else
+      iAlpha = 1.0_rsp
+    end if
+    if (present(beta)) then
+      iBeta = beta
+    else
+      iBeta = 0.0_rsp
+    end if
+
+    @:ASSERT(iTrans == 'n' .or. iTrans == 'N' .or. iTrans == 't' .or. iTrans == 'T' .or.&
+        & iTrans == 'c' .or. iTrans == 'C')
+    @:ASSERT(((size(a,dim=1) == size(y)) .and. (iTrans == 'n' .or. iTrans == 'N')) .or.&
+        & (size(a,dim=1) == size(x)))
+    @:ASSERT(((size(a,dim=2) == size(x)) .and. (iTrans == 'n' .or. iTrans == 'N')) .or.&
+        & (size(a,dim=2) == size(y)))
+
+    m = size(a,dim=1)
+    n = size(a,dim=2)
+
+    call sgemv( iTrans, m, n, iAlpha, a, m, x, 1, iBeta, y, 1 )
+
+  end subroutine gemv_real
+
+
+  !> double precision matrix*vector product
+  subroutine gemv_dble(y,a,x,alpha,beta,trans)
+
+    !> vector
+    real(rdp), intent(inout) :: y(:)
+
+    !> matrix
+    real(rdp), intent(in) :: a(:,:)
+
+    !> vector
+    real(rdp), intent(in) :: x(:)
+
+    !> optional scaling factor (defaults to 1)
+    real(rdp), intent(in), optional :: alpha
+
+    !> optional scaling factor (defaults to 0)
+    real(rdp), intent(in), optional :: beta
+
+    !> optional transpose (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c' and 'C'
+    character, intent(in), optional :: trans
+
+    integer :: n, m
+    character :: iTrans
+    real(rdp) :: iAlpha, iBeta
+
+    if (present(trans)) then
+      iTrans = trans
+    else
+      iTrans = 'n'
+    end if
+    if (present(alpha)) then
+      iAlpha = alpha
+    else
+      iAlpha = 1.0_rdp
+    end if
+    if (present(beta)) then
+      iBeta = beta
+    else
+      iBeta = 0.0_rdp
+    end if
+
+    @:ASSERT(iTrans == 'n' .or. iTrans == 'N' .or. iTrans == 't' .or. iTrans == 'T' .or.&
+        & iTrans == 'c' .or. iTrans == 'C')
+    @:ASSERT(((size(a,dim=1) == size(y)) .and. (iTrans == 'n' .or. iTrans == 'N')) .or.&
+        & (size(a,dim=1) == size(x)))
+    @:ASSERT(((size(a,dim=2) == size(x)) .and. (iTrans == 'n' .or. iTrans == 'N')) .or.&
+        & (size(a,dim=2) == size(y)))
+
+    m = size(a,dim=1)
+    n = size(a,dim=2)
+
+    call dgemv( iTrans, m, n, iAlpha, a, m, x, 1, iBeta, y, 1 )
+
+  end subroutine gemv_dble
+
+
+  #:for suffix, kind in REAL_KIND_PARAMS
+
+    !> Generalized matrix vector contraction Cij = Aijk * Bk
+    subroutine gemv231_${suffix}$(y, a, x, alpha, beta, trans)
+
+      !> matrix
+      real(r${kind}$p), intent(inout), contiguous, target :: y(:,:)
+
+      !> matrix
+      real(r${kind}$p), intent(in), contiguous, target :: a(:,:,:)
+
+      !> vector
+      real(r${kind}$p), intent(in) :: x(:)
+
+      !> optional scaling factor (defaults to 1)
+      real(r${kind}$p), intent(in), optional :: alpha
+
+      !> optional scaling factor (defaults to 0)
+      real(r${kind}$p), intent(in), optional :: beta
+
+      !> optional transpose (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c' and 'C'
+      character, intent(in), optional :: trans
+
+      real(r${kind}$p), pointer :: pY(:)
+      real(r${kind}$p), pointer :: pA(:,:)
+
+      pY(1 : size(y)) => y
+      pA(1 : size(a, dim=1) * size(a, dim=2), 1 : size(a, dim=3)) => a
+      call gemv(pY, pA, x, alpha, beta, trans)
+
+    end subroutine gemv231_${suffix}$
+
+  #:endfor
+
+  #:for suffix, kind in REAL_KIND_PARAMS
+
+    !> Generalized matrix vector contraction Cij = Aijk * Bk
+    subroutine gemv242_${suffix}$(y, a, x, alpha, beta, trans)
+
+      !> matrix
+      real(r${kind}$p), intent(inout), contiguous, target :: y(:,:)
+
+      !> matrix
+      real(r${kind}$p), intent(in), contiguous, target :: a(:,:,:,:)
+
+      !> matrix
+      real(r${kind}$p), intent(in), contiguous, target :: x(:,:)
+
+      !> optional scaling factor (defaults to 1)
+      real(r${kind}$p), intent(in), optional :: alpha
+
+      !> optional scaling factor (defaults to 0)
+      real(r${kind}$p), intent(in), optional :: beta
+
+      !> optional transpose (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c' and 'C'
+      character, intent(in), optional :: trans
+
+      real(r${kind}$p), pointer :: pX(:)
+      real(r${kind}$p), pointer :: pY(:)
+      real(r${kind}$p), pointer :: pA(:,:)
+
+      pY(1:size(y)) => y
+      pA(1:size(a, dim=1)*size(a, dim=2), 1:size(a, dim=3)*size(a, dim=4)) => a
+      pX(1:size(x)) => x
+      call gemv(pY, pA, pX, alpha, beta, trans)
+
+    end subroutine gemv242_${suffix}$
+
+  #:endfor
+
+
+#:for suffix, kind in REAL_KIND_PARAMS
+
+  !> ${suffix}$ matrix*matrix product
+  subroutine gemm_${suffix}$(C, A, B, alpha, beta, transA, transB, n, m, k, lda, ldb, ldc)
+
+    !> general matrix output
+    real(r${kind}$p), intent(inout) :: C(:,:)
+
+    !> general matrix
+    real(r${kind}$p), intent(in) :: A(:,:)
+
+    !> general matrix
+    real(r${kind}$p), intent(in) :: B(:,:)
+
+    !> defaults to 1 if not set
+    real(r${kind}$p), intent(in), optional :: alpha
+
+    !> defaults to 0 if not set
+    real(r${kind}$p), intent(in), optional :: beta
+
+    !> optional transpose of A matrix (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c'
+    !> and 'C'
+    character, intent(in), optional :: transA
+
+    !> optional transpose of B matrix (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T', 'c'
+    !> and 'C'
+    character, intent(in), optional :: transB
+
+    !> specifies the number of columns of the matrix C
+    integer, intent(in), optional :: n
+
+    !> specifies the number of rows of the matrix C
+    integer, intent(in), optional :: m
+
+    !> specifies the internal number of elements in Op(A)_ik Op(B)_kj
+    integer, intent(in), optional :: k
+
+    !> leading dimensions
+    integer, intent(in), optional :: lda, ldb, ldc
+
+    integer :: ilda, ildb, ildc
+    integer :: in, im, ik
+    character :: iTransA, iTransB
+    real(r${kind}$p) :: iAlpha, iBeta
+
+    if (present(transA)) then
+      iTransA = transA
+    else
+      iTransA = 'n'
+    end if
+    if (present(transB)) then
+      iTransB = transB
+    else
+      iTransB = 'n'
+    end if
+
+    @:ASSERT(iTransA == 'n' .or. iTransA == 'N' .or. iTransA == 't'&
+        & .or. iTransA == 'T' .or. iTransA == 'c' .or. iTransA == 'C')
+    @:ASSERT(iTransB == 'n' .or. iTransB == 'N' .or. iTransB == 't'&
+        & .or. iTransB == 'T' .or. iTransB == 'c' .or. iTransB == 'C')
+
+    if (present(alpha)) then
+      iAlpha = alpha
+    else
+      iAlpha = 1.0_r${kind}$p
+    end if
+    if (present(beta)) then
+      iBeta = beta
+    else
+      iBeta = 0.0_r${kind}$p
+    end if
+
+  #:for CASES in [('a'), ('b'), ('c')]
+    if (present(ld${CASES}$)) then
+      ild${CASES}$ = ld${CASES}$
+    else
+      ild${CASES}$ = size(${CASES}$,dim=1)
+    end if
+  #:endfor
+
+    if (present(m)) then
+      im = m
+    else
+      if (iTransA == 'n' .or. iTransA == 'N') then
+        im = size(A,dim=1)
+      else
+        im = size(A,dim=2)
+      end if
+    end if
+    if (present(n)) then
+      in = n
+    else
+      in = size(c,dim=2)
+    end if
+    if (present(k)) then
+      ik = k
+    else
+      if (iTransA == 'n' .or. iTransA == 'N') then
+        ik = size(A,dim=2)
+      else
+        ik = size(A,dim=1)
+      end if
+    end if
+
+    @:ASSERT(im>0)
+    @:ASSERT(in>0)
+    @:ASSERT(ik>0)
+    @:ASSERT(((ilda>=im).and.(iTransA == 'n' .or. iTransA == 'N'))&
+        & .or. (size(a,dim=2)>=im))
+    @:ASSERT(ildc>=im)
+    @:ASSERT(((size(b,dim=2)>=in).and.(iTransB == 'n' .or. iTransB == 'N'))&
+        & .or. (ildb>=in))
+    @:ASSERT(size(c,dim=2)>=in)
+    @:ASSERT(((size(a,dim=2)>=ik).and.(iTransA == 'n' .or. iTransA == 'N'))&
+        & .or. (ilda>=ik))
+    @:ASSERT(((ildb>=ik).and.(iTransB == 'n' .or. iTransB == 'N'))&
+        & .or. (size(b,dim=2)>=ik))
+
+    call ${kind}$gemm(iTransA,iTransB,im,in,ik,iAlpha,A,ilda,B,ildb,iBeta,C,ildc)
+
+  end subroutine gemm_${suffix}$
+
+#:endfor
+
+
+#:for suffix, kind in REAL_KIND_PARAMS
+
+  !> Generalized real matrix matrix contraction (Cijl = Aijk * Bkl)
+  subroutine gemm332_${suffix}$(C, A, B, alpha, beta, transA, transB)
+
+    !> general matrix output
+    real(r${kind}$p), intent(inout), target, contiguous :: C(:,:,:)
+
+    !> general matrix
+    real(r${kind}$p), intent(in), target, contiguous :: A(:,:,:)
+
+    !> general matrix
+    real(r${kind}$p), intent(in) :: B(:,:)
+
+    !> defaults to 1 if not set
+    real(r${kind}$p), intent(in), optional :: alpha
+
+    !> defaults to 0 if not set
+    real(r${kind}$p), intent(in), optional :: beta
+
+    !> optional transpose of A matrix (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T',
+    !> 'c' and 'C'. Note this acts on the compound index ij
+    character, intent(in), optional :: transA
+
+    !> optional transpose of B matrix (defaults to 'n'), allowed choices are 'n', 'N', 't', 'T',
+    !> 'c' and 'C'
+    character, intent(in), optional :: transB
+
+    real(r${kind}$p), pointer :: pA(:,:), pC(:,:)
+
+    pA(1 : size(A, dim=1) * size(A, dim=2), 1 : size(A, dim=3)) => A
+    pC(1 : size(C, dim=1) * size(C, dim=2), 1 : size(C, dim=3)) => C
+    call gemm(pC, pA, B, alpha, beta, transA, transB)
+
+  end subroutine gemm332_${suffix}$
+
+#:endfor
+
+end module dftbp_math_blasroutines

--- a/prog/fortnet/lib_dftbp/lbfgs.F90
+++ b/prog/fortnet/lib_dftbp/lbfgs.F90
@@ -21,6 +21,8 @@ module dftbp_lbfgs
   use dftbp_assert
   use dftbp_message
   use dftbp_linemin, only : TLineMin, TLineMin_init
+  use dftbp_math_blasroutines, only : gemv
+
   implicit none
   private
 
@@ -942,8 +944,8 @@ contains
     db = bb - aa
     dc = cc - aa
     denom = (db * dc)**2 * (db - dc)
-    d1(:,:) = reshape([ dc**2, -dc**3, -db**2, db**3], [2, 2])
-    temp(:) = matmul(d1, [fb - fa - fpa * db, fc - fa - fpa * dc])
+    d1(:,:) = reshape([dc**2, -dc**3, -db**2, db**3], [2, 2])
+    call gemv(temp, d1, [fb - fa - fpa * db, fc - fa - fpa * dc])
 
     ta = temp(1) / denom
     tb = temp(2) / denom

--- a/prog/fortnet/lib_io/fnetdata.F90
+++ b/prog/fortnet/lib_io/fnetdata.F90
@@ -976,11 +976,15 @@ contains
       if (dataset%tGlobalTargets) then
         call h5ltfx_read_dataset_double_f(datapoint_grp, 'globaltargets',&
             & dataset%globalTargets(iDatapoint)%array)
+      else
+        allocate(dataset%globalTargets(iDatapoint)%array(0))
       end if
 
       if (dataset%tAtomicTargets) then
         call h5ltfx_read_dataset_double_f(datapoint_grp, 'atomictargets',&
             & dataset%atomicTargets(iDatapoint)%array)
+      else
+        allocate(dataset%atomicTargets(iDatapoint)%array(0, 0))
       end if
 
       if (dataset%tExtFeatures) then

--- a/prog/fortnet/lib_nn/bpnn.F90
+++ b/prog/fortnet/lib_nn/bpnn.F90
@@ -439,7 +439,7 @@ contains
       call this%sysTrain(trainFeatures(iSys)%array, trainDataset%globalTargets(iSys)%array,&
           & trainDataset%atomicTargets(iSys)%array, trainDataset%atomicWeights(iSys)%array,&
           & trainDataset%localAtToGlobalSp(iSys)%array, lossgrad, ddTmp,&
-          & predicts%sys(iSys)%array(:,:))
+          & predicts%sys(iSys)%array)
       ! collect gradients of the system
       do iGlobalSp = 1, size(this%nets)
         do iLayer = 1, size(this%dims)
@@ -900,7 +900,7 @@ contains
 
 
   !> Calculates the Jacobian matrix element of the atomic outputs w.r.t. the input features.
-  pure function TBpnn_iJacobian(this, input, localAtToGlobalSp) result(jacobian)
+  function TBpnn_iJacobian(this, input, localAtToGlobalSp) result(jacobian)
 
     !> representation of a Behler-Parrinello neural network
     class(TBpnn), intent(in) :: this

--- a/prog/fortnet/prg_fnet/fortnet.F90
+++ b/prog/fortnet/prg_fnet/fortnet.F90
@@ -239,7 +239,6 @@ contains
           call checkAcsfDatasetCompatibility(prog%trainDataset, trainAcsf)
         end if
         call bpnn%fromFile(prog%inp%data%netstatpath)
-        print *, bpnn%nGlobalTargets
         if (prog%inp%option%mode == 'validate') then
           call checkBpnnDatasetCompatibility(prog%trainDataset, bpnn%atomicNumbers,&
               & bpnn%nGlobalTargets, bpnn%nAtomicTargets, allowSpSubset=.true.)
@@ -705,7 +704,6 @@ contains
       write(stdout, '(A,/)') repeat('-', 68)
     case ('validate', 'predict')
       write(stdOut, '(A)', advance='no') 'Start feeding...'
-      print *, bpnn%nGlobalTargets
       call TPredicts_init(predicts, prog%trainDataset%nDatapoints, bpnn%nGlobalTargets,&
           & bpnn%nAtomicTargets, prog%trainDataset%localAtToAtNum)
       predicts%sys = bpnn%predictBatch(prog%features%trainFeatures, prog%env,&

--- a/sys/generic.cmake
+++ b/sys/generic.cmake
@@ -38,3 +38,8 @@ set(Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}"
 #
 # External libraries
 #
+
+# LAPACK and BLAS
+#set(LAPACK_LIBRARY "lapack;blas" CACHE STRING "LAPACK and BLAS libraries to link")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING
+#  "Directories where LAPACK and BLAS libraries can be found")

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -37,3 +37,10 @@ set(Fortran_FLAGS_DEBUG "-g -Wall -std=f2008ts -pedantic -fbounds-check"
 #
 # External libraries
 #
+
+# LAPACK and BLAS
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+#set(BLAS_LIBRARY "openblas" CACHE STRING "BLAS libraries to link")
+#set(BLAS_LIBRARY_DIR "" CACHE STRING "Directories where BLAS libraries can be found")
+#set(LAPACK_LIBRARY "NONE" CACHE STRING "LAPACK libraries to link")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING "Directories where LAPACK libraries can be found")

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -34,3 +34,14 @@ set(Fortran_FLAGS_DEBUG "-g -warn all -stand f08 -check -diag-error-limit 1 -tra
 #
 # External libraries
 #
+
+# LAPACK and BLAS
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+
+# set(BLAS_LIBRARY "mkl_intel_lp64;mkl_sequential;mkl_core" CACHE STRING "BLAS libraries to link")
+# set(BLAS_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
+#     "Directories where BLAS libraries can be found")
+
+# set(LAPACK_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
+#    "Directories where LAPACK libraries can be found")
+set(LAPACK_LIBRARY "NONE")

--- a/sys/nag.cmake
+++ b/sys/nag.cmake
@@ -33,3 +33,10 @@ set(Fortran_FLAGS_DEBUG "-g -f2008 -nan -C=all"
 #
 # External libraries
 #
+
+# LAPACK and BLAS
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+#set(BLAS_LIBRARY "openblas" CACHE STRING "BLAS libraries to link")
+#set(BLAS_LIBRARY_DIR "" CACHE STRING "Directories where BLAS libraries can be found")
+#set(LAPACK_LIBRARY "NONE" CACHE STRING "LAPACK libraries to link")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING "Directories where LAPACK libraries can be found")


### PR DESCRIPTION
Until now, the matmul intrinsic was used for matrix-matrix and matrix-vector multiplication, which has now been substituted by [gemm](http://www.netlib.org/lapack/explore-html/d1/d54/group__double__blas__level3_gaeda3cbd99c8fb834a60a6412878226e1.html) and [gemv](www.netlib.org/lapack/explore-html/d7/d15/group__double__blas__level2_gadd421a107a488d524859b4a64c1901a9.html) respectively.

Closes #62.