### PR TITLE
Restrict FORD docmarkers to actual function signature

### DIFF
--- a/prog/fortnet/lib_analysis/forces.F90
+++ b/prog/fortnet/lib_analysis/forces.F90
@@ -93,7 +93,7 @@ contains
     !> absolute shift of each atomic coordinate
     real(dp), intent(in) :: delta
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAtom, iCoord
 
     allocate(this%geos(size(geos)))
@@ -126,7 +126,7 @@ contains
     !> serialized geometries
     type(TGeometry), intent(out), allocatable :: geos(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAtom, iCoord, nTotGeometries, ind
 
     nTotGeometries = 0
@@ -159,7 +159,7 @@ contains
     !> flat reference structure to nest
     type(TGeometry), intent(in) :: geos(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAtom, iCoord, ind
 
     ind = 1
@@ -200,22 +200,22 @@ contains
     !> absolute shift of each atomic coordinate
     real(dp), intent(in) :: delta
 
-    !> extended index mapping local atom --> global species index
+    !! extended index mapping local atom --> global species index
     type(TIntArray1D), allocatable :: localAtToGlobalSpExtended(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> network predictions for rattled geometries with one perturbed atom
+    !! network predictions for rattled geometries with one perturbed atom
     type(TPredicts) :: predicts, resPredicts
 
-    !> obtained atomic forces
+    !! obtained atomic forces
     type(TForces) :: forces, resForces
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iGeo, iAtom, iCoord, iStart, iEnd, ii, ind
 
   #:if WITH_MPI
@@ -335,19 +335,19 @@ contains
     !> index mapping local atom --> global species index
     type(TIntArray1D), intent(in) :: localAtToGlobalSp(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> network predictions for rattled geometries with one perturbed atom
+    !! network predictions for rattled geometries with one perturbed atom
     type(TPredicts) :: predicts, resPredicts
 
-    !> obtained atomic forces
+    !! obtained atomic forces
     type(TForces) :: forces, resForces
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom, iForceAtom, iAcsf, iCoord, iStart, iEnd
 
   #:if WITH_MPI

--- a/prog/fortnet/lib_common/loss.F90
+++ b/prog/fortnet/lib_common/loss.F90
@@ -51,7 +51,7 @@ module fnet_loss
       !> optional weighting of individual datapoints
       integer, intent(in), optional :: weights(:)
 
-      !> total loss of predictions, in comparison to targets
+      !! total loss of predictions, in comparison to targets
       real(dp) :: loss
 
     end function lossFunc
@@ -69,7 +69,7 @@ module fnet_loss
       !> target reference data
       real(dp), intent(in) :: targets(:,:)
 
-      !> loss gradients w.r.t predictions and targets
+      !! loss gradients w.r.t predictions and targets
       real(dp) :: grads(size(targets, dim=1), size(targets, dim=2))
 
     end function lossGradientFunc
@@ -90,7 +90,7 @@ module fnet_loss
       !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
       real(dp), intent(in) :: alpha
 
-      !> total regularization loss
+      !! total regularization loss
       real(dp) :: loss
 
     end function reguFunc
@@ -127,7 +127,7 @@ contains
     !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
     real(dp), intent(in) :: alpha
 
-    !> total regularization loss
+    !! total regularization loss
     real(dp) :: loss
 
     loss = 0.0_dp
@@ -147,7 +147,7 @@ contains
     !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
     real(dp), intent(in) :: alpha
 
-    !> total regularization loss
+    !! total regularization loss
     real(dp) :: loss
 
     loss = lambda / real(size(weights), dp) * sum(abs(weights))
@@ -167,7 +167,7 @@ contains
     !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
     real(dp), intent(in) :: alpha
 
-    !> total regularization loss
+    !! total regularization loss
     real(dp) :: loss
 
     loss = lambda / (2.0_dp * real(size(weights), dp)) * sum(weights**2)
@@ -187,7 +187,7 @@ contains
     !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
     real(dp), intent(in) :: alpha
 
-    !> total regularization loss
+    !! total regularization loss
     real(dp) :: loss
 
     loss = lambda / real(size(weights), dp) * ((1 - alpha) / 2.0_dp * sum(weights**2)&
@@ -205,7 +205,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> deviation of predictions, in comparison to targets
+    !! deviation of predictions, in comparison to targets
     real(dp) :: dev(size(targets))
 
     dev(:) = predicts - targets
@@ -222,7 +222,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:,:)
 
-    !> loss gradients w.r.t predictions and targets
+    !! loss gradients w.r.t predictions and targets
     real(dp) :: grads(size(targets, dim=1), size(targets, dim=2))
 
     grads(:,:) = (predicts - targets) / abs(predicts - targets)
@@ -239,7 +239,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:,:)
 
-    !> loss gradients w.r.t predictions and targets
+    !! loss gradients w.r.t predictions and targets
     real(dp) :: grads(size(targets, dim=1), size(targets, dim=2))
 
     grads(:,:) = 100.0_dp * (predicts - targets) / (targets**2 * abs(predicts / targets - 1.0_dp))
@@ -256,7 +256,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:,:)
 
-    !> loss gradients w.r.t predictions and targets
+    !! loss gradients w.r.t predictions and targets
     real(dp) :: grads(size(targets, dim=1), size(targets, dim=2))
 
     grads(:,:) = 2.0_dp * (predicts - targets)
@@ -273,7 +273,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:,:)
 
-    !> loss gradients w.r.t predictions and targets
+    !! loss gradients w.r.t predictions and targets
     real(dp) :: grads(size(targets, dim=1), size(targets, dim=2))
 
     grads(:,:) = (predicts - targets) / (sqrt((predicts - targets)**2))
@@ -290,7 +290,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
     loss = sum(abs(targets - predicts)) / real(size(predicts), dp)
@@ -307,7 +307,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> summed mean absolute percentage loss of predictions, in comparison to targets
+    !! summed mean absolute percentage loss of predictions, in comparison to targets
     real(dp) :: loss
 
     loss = 100.0_dp * sum(abs((targets - predicts) / targets)) / real(size(predicts), dp)
@@ -324,7 +324,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> summed mean squared loss of predictions, in comparison to targets
+    !! summed mean squared loss of predictions, in comparison to targets
     real(dp) :: loss
 
     loss = sum((targets - predicts)**2) / real(size(predicts), dp)
@@ -341,7 +341,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> summed mean squared logarithmic loss of predictions, in comparison to targets
+    !! summed mean squared logarithmic loss of predictions, in comparison to targets
     real(dp) :: loss
 
     loss = sum((log(targets + 1.0_dp) - log(predicts + 1.0_dp))**2) / real(size(predicts), dp)
@@ -358,7 +358,7 @@ contains
     !> target reference data
     real(dp), intent(in) :: targets(:)
 
-    !> summed root mean square loss of predictions, in comparison to targets
+    !! summed root mean square loss of predictions, in comparison to targets
     real(dp) :: loss
 
     loss = sqrt(sum((targets - predicts)**2) / real(size(predicts), dp))
@@ -384,19 +384,19 @@ contains
     !> optional weighting of individual datapoints
     integer, intent(in), optional :: weights(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
-    !> temporary loss storage
+    !! temporary loss storage
     real(dp) :: tmpLoss
 
-    !> weighting of individual datapoints
+    !! weighting of individual datapoints
     integer, allocatable :: weighting(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom
     real(dp) :: nValues
 
@@ -455,19 +455,19 @@ contains
     !> optional weighting of individual datapoints
     integer, intent(in), optional :: weights(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
-    !> temporary loss storage
+    !! temporary loss storage
     real(dp) :: tmpLoss
 
-    !> weighting of individual datapoints
+    !! weighting of individual datapoints
     integer, allocatable :: weighting(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom
     real(dp) :: nValues
 
@@ -526,19 +526,19 @@ contains
     !> optional weighting of individual datapoints
     integer, intent(in), optional :: weights(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
-    !> temporary loss storage
+    !! temporary loss storage
     real(dp) :: tmpLoss
 
-    !> weighting of individual datapoints
+    !! weighting of individual datapoints
     integer, allocatable :: weighting(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom
     real(dp) :: nValues
 
@@ -597,19 +597,19 @@ contains
     !> optional weighting of individual datapoints
     integer, intent(in), optional :: weights(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
-    !> temporary loss storage
+    !! temporary loss storage
     real(dp) :: tmpLoss
 
-    !> weighting of individual datapoints
+    !! weighting of individual datapoints
     integer, allocatable :: weighting(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom
     real(dp) :: nValues
 
@@ -668,19 +668,19 @@ contains
     !> optional weighting of individual datapoints
     integer, intent(in), optional :: weights(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> summed mean absolute loss of predictions, in comparison to targets
+    !! summed mean absolute loss of predictions, in comparison to targets
     real(dp) :: loss
 
-    !> temporary loss storage
+    !! temporary loss storage
     real(dp) :: tmpLoss
 
-    !> weighting of individual datapoints
+    !! weighting of individual datapoints
     integer, allocatable :: weighting(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom
     real(dp) :: nValues
 
@@ -733,16 +733,16 @@ contains
     !> atomic target reference data
     type(TRealArray2D), intent(in) :: atomicTargets(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> absolute minium deviation between predictions and targets
+    !! absolute minium deviation between predictions and targets
     real(dp) :: err
 
-    !> temporary error storage
+    !! temporary error storage
     real(dp) :: globalTargetsErr, atomicTargetsErr, tmpErr
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iSys
 
     if (predicts%nGlobalTargets > 0) then
@@ -790,16 +790,16 @@ contains
     !> atomic target reference data
     type(TRealArray2D), intent(in) :: atomicTargets(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> absolute maximum deviation between predictions and targets
+    !! absolute maximum deviation between predictions and targets
     real(dp) :: err
 
-    !> temporary error storage
+    !! temporary error storage
     real(dp) :: globalTargetsErr, atomicTargetsErr, tmpErr
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iSys
 
     if (predicts%nGlobalTargets > 0) then

--- a/prog/fortnet/lib_common/nestedtypes.F90
+++ b/prog/fortnet/lib_common/nestedtypes.F90
@@ -236,7 +236,7 @@ contains
     !> reference array to get allocation structure from, i.e. number of atoms per structure
     type(TIntArray1D), intent(in) :: refArray(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iSys
 
     ! assume that number of system-wide/atomic targets remains the same throughout datapoints
@@ -281,10 +281,10 @@ contains
     !> representation of bias derivatives
     type(TBiasDerivs), intent(out) :: db
 
-    !> number of arrays in the bias structure
+    !! number of arrays in the bias structure
     integer :: nArrays
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     nArrays = size(dims)
@@ -311,10 +311,10 @@ contains
     !> weight derivatives
     type(TWeightDerivs), intent(out) :: dw
 
-    !> number of arrays in the weight structure
+    !! number of arrays in the weight structure
     integer :: nArrays
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     nArrays = size(dims)
@@ -350,10 +350,10 @@ contains
     !> elastic net weighting between lasso and ridge (0 = ridge, 1 = lasso)
     real(dp), intent(in) :: alpha
 
-    !> temporary array to build up signum function values
+    !! temporary array to build up signum function values
     real(dp), allocatable :: sgn(:,:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iLayer
 
     do iLayer = 1, size(this%dw)
@@ -382,7 +382,7 @@ contains
     !> representation of temporary layer storage container
     type(TMultiLayerStruc), intent(out) :: this
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj
 
     allocate(this%struc(nStrucs))
@@ -410,7 +410,7 @@ contains
     !> representation weight and bias derivatives
     class(TDerivs), intent(out) :: derivs
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iStruc
 
     allocate(derivs%dw(nStrucs))
@@ -436,7 +436,7 @@ contains
     !> all gradients collected in 1d-array, shape: [nTotGrads, nSpecies]
     real(dp), intent(out), allocatable :: ddSerial(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iStruc, iLayer, nStrucs, nArrays, ii, jj, ind
 
     nStrucs = size(this%db)
@@ -476,7 +476,7 @@ contains
     !> representation of weight and bias derivatives
     class(TDerivs), intent(inout) :: this
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iStruc, iArray, nStrucs, nArrays
 
     nStrucs = size(this%db)

--- a/prog/fortnet/lib_common/parallel.F90
+++ b/prog/fortnet/lib_common/parallel.F90
@@ -34,10 +34,10 @@ contains
     !> start and end index of current tile
     integer, intent(out) :: iStart, iEnd
 
-    !> size of splitted index regions
+    !! size of splitted index regions
     integer :: splitSize
 
-    !> number of systems that exceeds integer times nProcs
+    !! number of systems that exceeds integer times nProcs
     integer :: offset
 
     splitSize = nSystems / nProcs

--- a/prog/fortnet/lib_common/random.F90
+++ b/prog/fortnet/lib_common/random.F90
@@ -38,10 +38,10 @@ contains
     !> array that will be shuffled on exit
     integer, intent(inout) :: array(:)
 
-    !> temporarily stores a real-valued random number
+    !! temporarily stores a real-valued random number
     real(dp) :: rnd
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, rndpos, tmp
 
     do ii = size(array), 2, -1
@@ -76,19 +76,19 @@ contains
     !> optional minimal value specification
     real(dp), intent(in), optional :: min
 
-    !> variance of normal distribution
+    !! variance of normal distribution
     real(dp) :: var
 
-    !> scaling of distribution (default: 1.0)
+    !! scaling of distribution (default: 1.0)
     real(dp) :: scale
 
-    !> minimal value specification
+    !! minimal value specification
     real(dp) :: minval
 
-    !> calculated boundary for random numbers to fulfill minimal value specification
+    !! calculated boundary for random numbers to fulfill minimal value specification
     real(dp) :: bound
 
-    !> luxury random numbers
+    !! luxury random numbers
     real(dp) :: rnd(size(array))
 
     if (present(gain)) then
@@ -139,19 +139,19 @@ contains
     !> optional minimal value specification
     real(dp), intent(in), optional :: min
 
-    !> variance of normal distribution
+    !! variance of normal distribution
     real(dp) :: var
 
-    !> scaling of distribution (default: 1.0)
+    !! scaling of distribution (default: 1.0)
     real(dp) :: scale
 
-    !> minimal value specification
+    !! minimal value specification
     real(dp) :: minval
 
-    !> calculated boundary for random numbers to fulfill minimal value specification
+    !! calculated boundary for random numbers to fulfill minimal value specification
     real(dp) :: bound
 
-    !> luxury random numbers
+    !! luxury random numbers
     real(dp) :: rnd(size(array, dim=1), size(array, dim=2))
 
     if (present(gain)) then

--- a/prog/fortnet/lib_common/workarounds.F90
+++ b/prog/fortnet/lib_common/workarounds.F90
@@ -28,7 +28,7 @@ contains
     !> selector to search for
     character(len=*), intent(in) :: selector
 
-    !> position in character array
+    !! position in character array
     integer :: iPos
 
     iPos = 1

--- a/prog/fortnet/lib_descriptors/acsf.F90
+++ b/prog/fortnet/lib_descriptors/acsf.F90
@@ -198,7 +198,7 @@ contains
     !> optional atom identifier index
     integer, intent(in), optional :: atomId
 
-    !> error messages
+    !! error messages
     character(len=:), allocatable :: msg1, msg2
 
     msg1 = 'Superflous argument(s) for selected function type provided.'
@@ -291,25 +291,25 @@ contains
     !> optional atom identifier index
     integer, intent(in), optional :: atomId
 
-    !> stepsize for center parameter
+    !! stepsize for center parameter
     real(dp) :: rsStep
 
-    !> width parameter for G2 and G5 function
+    !! width parameter for G2 and G5 function
     real(dp) :: g2eta, g5eta
 
-    !> peak positions for G2 function
+    !! peak positions for G2 function
     real(dp), allocatable :: g2rs(:)
 
-    !> lambda parameters for G5 function
+    !! lambda parameters for G5 function
     real(dp), allocatable :: g5lambda(:)
 
-    !> xi parameters for G5 function
+    !! xi parameters for G5 function
     real(dp), allocatable :: g5xi(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     real(dp) :: xi
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj, ind, iRadial, iAngular, identifier
 
     if (present(atomId)) then
@@ -373,7 +373,7 @@ contains
     !> representation of ACSF functions to append
     type(TGFunctions), intent(in) :: functions
 
-    !> temporary storage
+    !! temporary storage
     type(TGFunctions) :: tmp
 
     if (.not. allocated(functions%func)) then
@@ -404,7 +404,7 @@ contains
     !> total number of ACSF mappings per atom
     integer, intent(in) :: nAcsfVals
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iGeo
 
     allocate(this%vals(size(geos)))
@@ -429,7 +429,7 @@ contains
     !> total number of ACSF mappings per atom
     integer, intent(in) :: nAcsfVals
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iSys
 
     allocate(this%vals(size(geos)))
@@ -451,7 +451,7 @@ contains
     !> weighting of each corresponding datapoint
     integer, intent(in) :: weights(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAtom, nTotAtoms
 
     if (allocated(this%zPrec)) then
@@ -493,7 +493,7 @@ contains
     !> representation of ACSF mappings
     class(TAcsf), intent(inout) :: this
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAcsf
 
     if (.not. allocated(this%zPrec)) then
@@ -518,7 +518,7 @@ contains
     !> representation of ACSF mappings
     class(TAcsf), intent(inout) :: this
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, iAcsf
 
     if (.not. allocated(this%zPrec)) then
@@ -561,19 +561,19 @@ contains
     !> storage container of means and variances to calculate z-score
     real(dp), intent(in), optional :: zPrec(:,:)
 
-    !> atom dependent scaling parameters for cutoff function
+    !! atom dependent scaling parameters for cutoff function
     type(TRealArray2D), allocatable :: extFeatures(:)
 
-    !> temporary storage of ACSF values of each node
+    !! temporary storage of ACSF values of each node
     type(TMultiAcsfVals) :: tmpVals
 
-    !> weighting of each corresponding datapoint
+    !! weighting of each corresponding datapoint
     integer, allocatable :: weighting(:)
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iStart, iEnd
 
     allocate(weighting(size(geos)))
@@ -658,16 +658,16 @@ contains
     !> optional atom dependent scaling parameters for cutoff function
     type(TRealArray2D), intent(in), optional :: extFeaturesInp(:)
 
-    !> atom dependent scaling parameters for cutoff function
+    !! atom dependent scaling parameters for cutoff function
     type(TRealArray2D), allocatable :: extFeatures(:)
 
-    !> temporary storage of ACSF derivatives of each node
+    !! temporary storage of ACSF derivatives of each node
     type(TMultiAcsfPrimeVals) :: tmpValsPrime
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iStart, iEnd
 
     ! prevent for accessing an unallocated array
@@ -743,10 +743,10 @@ contains
     !> mask to determine which atoms to keep (does also contain iAtom)
     integer, intent(out), allocatable, optional :: tKeep(:)
 
-    !> temporary mask to determine which atoms to keep
+    !! temporary mask to determine which atoms to keep
     integer, allocatable :: tmp(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtom1, iAtom2, ind
 
     allocate(tmp(geo%nAtom))
@@ -812,19 +812,19 @@ contains
     !> atom dependent scaling parameters for cutoff function
     real(dp), intent(in) :: extFeatures(:,:)
 
-    !> geometries reduced to atoms of a single species
+    !! geometries reduced to atoms of a single species
     type(TGeometry) :: geo1, geo2
 
-    !> atomic prefactor of central atom
+    !! atomic prefactor of central atom
     real(dp) :: atomId
 
-    !> atomic prefactors of neighboring atoms
+    !! atomic prefactors of neighboring atoms
     real(dp), allocatable :: atomIds1(:), atomIds2(:)
 
-    !> neighbor coordinates and squared distances
+    !! neighbor coordinates and squared distances
     real(dp), allocatable :: neighDists1(:), neighDists2(:), neighCoords1(:,:), neighCoords2(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtom, iAcsf, iAtomOut1
 
     do iAtom = 1, geo%nAtom
@@ -885,22 +885,22 @@ contains
     !> atom dependent scaling parameters for cutoff function
     real(dp), intent(in), optional :: extFeatures(:,:)
 
-    !> geometries reduced to atoms of a single species
+    !! geometries reduced to atoms of a single species
     type(TGeometry) :: geo1, geo2
 
-    !> atomic prefactor of central atom
+    !! atomic prefactor of central atom
     real(dp) :: atomId
 
-    !> atomic prefactors of neighboring atoms
+    !! atomic prefactors of neighboring atoms
     real(dp), allocatable :: atomIds1(:), atomIds2(:)
 
-    !> neighbor coordinates and squared distances
+    !! neighbor coordinates and squared distances
     real(dp), allocatable :: neighDists1(:), neighDists2(:), neighCoords1(:,:), neighCoords2(:,:)
 
-    !> global indices of neighboring atoms in the reduced geometry
+    !! global indices of neighboring atoms in the reduced geometry
     integer, allocatable  :: atomIndices1(:), atomIndices2(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtom, iAcsf, iAtomOut1
 
     do iAtom = 1, geo%nAtom
@@ -966,9 +966,6 @@ contains
     !> index of iAtom after reduction of geo1
     integer, intent(out) :: iAtomOut1
 
-    ! !> atomic prefactors of central atom
-    ! real(dp), intent(out) :: atomId1, atomId2
-
     !> atomic prefactors of neighboring atoms
     real(dp), intent(out), allocatable :: atomIds1(:), atomIds2(:)
 
@@ -981,16 +978,16 @@ contains
     !> neighbour atom indices (dummy)
     integer,  intent(out), allocatable, optional :: atomIndices1_(:), atomIndices2_(:)
 
-    !> neighbor atom indices
+    !! neighbor atom indices
     integer,  allocatable :: atomIndices1(:), atomIndices2(:)
 
-    !> masks to determine which atoms to keep while reducing the geometry
+    !! masks to determine which atoms to keep while reducing the geometry
     integer, allocatable :: tKeep1(:), tKeep2(:)
 
-    !> true, if a species-resolved neighborlist is desired
+    !! true, if a species-resolved neighborlist is desired
     logical :: tSpeciesResolved
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iAtomOut2
 
     if (all(gFunction%atomicNumbers == 0)) then
@@ -1088,25 +1085,25 @@ contains
     !> neighbor atom indices of all iterations
     integer, intent(out), allocatable :: allAtomIndices(:)
 
-    !> instance of dynamic neighbour list
+    !! instance of dynamic neighbour list
     type(TDynNeighList), target :: neighList
 
-    !> pointer to dynamic neighbour list
+    !! pointer to dynamic neighbour list
     type(TDynNeighList), pointer :: pNeighList
 
-    !> instance of dynamic neighbour list iterator
+    !! instance of dynamic neighbour list iterator
     type(TNeighIterator) :: neighIter
 
-    !> obtained neighbor coordinates and distances
+    !! obtained neighbor coordinates and distances
     real(dp) :: neighDists(iterChunkSize), neighCoords(3, iterChunkSize)
 
-    !> obtained neighbor atom indices
+    !! obtained neighbor atom indices
     integer :: atomIndices(iterChunkSize)
 
-    !> temporary coordinate storage
+    !! temporary coordinate storage
     real(dp), allocatable :: tmpCoords(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: nNeigh, nTotNeigh
 
     call TDynNeighList_init(neighList, rCut, geo%nAtom, geo%tPeriodic)
@@ -1148,10 +1145,10 @@ contains
     !> system geometry container
     type(TGeometry), intent(in) :: geo
 
-    !> Indices of atoms to calculate distance for
+    !> indices of atoms to calculate distance for
     integer, intent(in) :: iAt1, iAt2
 
-    !> Obtained distance betweeen the two atoms
+    !! obtained distance betweeen the two atoms
     real(dp) :: distance
 
     distance = norm2(geo%coords(:, iAt2) - geo%coords(:, iAt1))
@@ -1171,7 +1168,7 @@ contains
     !> distances of reference atom to first and second neighbor
     real(dp), intent(in) :: neighDist1, neighDist2
 
-    !> obtained angle betweeen the three atoms
+    !! obtained angle betweeen the three atoms
     real(dp) :: theta
 
     theta = acos(dot_product((neighCoords1 - atomCoords), (neighCoords2 - atomCoords))&
@@ -1196,7 +1193,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> resulting cutoff function value
+    !! resulting cutoff function value
     real(dp) :: res
 
     if (rr > rcut) then
@@ -1224,7 +1221,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> resulting cutoff function value
+    !! resulting cutoff function value
     real(dp) :: res
 
     res = 0.5_dp * atomId1 * atomId2 * (cos(pi * rr / rcut) + 1.0_dp)
@@ -1250,7 +1247,7 @@ contains
     !> derivative order
     integer, intent(in) :: deriv
 
-    !> resulting cutoff derivative value
+    !! resulting cutoff derivative value
     real(dp) :: res
 
     ! here we use the formula for the n-th derivative of cos(ax)
@@ -1275,7 +1272,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> corresponding activation function values
+    !! corresponding activation function values
     real(dp) :: res(size(rr))
 
     where (rr > rcut)
@@ -1302,7 +1299,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> corresponding symmetry function values
+    !! corresponding symmetry function values
     real(dp) :: g1
 
     if (size(rr) == 0) then
@@ -1335,7 +1332,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> corresponding symmetry function values
+    !! corresponding symmetry function values
     real(dp) :: g2
 
     if (size(rr) == 0) then
@@ -1365,7 +1362,7 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> corresponding symmetry function values
+    !! corresponding symmetry function values
     real(dp) :: g3
 
     if (size(rr) == 0) then
@@ -1408,13 +1405,13 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    ! distance between atom j of species 1 and atom k of species 2
+    !! distance between atom j of species 1 and atom k of species 2
     real(dp) :: distjk
 
-    !> corresponding symmetry function values
+    !! corresponding symmetry function values
     real(dp) :: g4
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: jj, kk
 
     g4 = 0.0_dp
@@ -1471,10 +1468,10 @@ contains
     !> cutoff radius
     real(dp), intent(in) :: rcut
 
-    !> corresponding symmetry function values
+    !! corresponding symmetry function values
     real(dp) :: g5
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: jj, kk
 
     g5 = 0.0_dp
@@ -1515,13 +1512,13 @@ contains
     !> atomic prefactors, neighbor coordinates and squared distances of second neighborlist
     real(dp), intent(in) :: atomIds2(:), neighDists2(:), neighCoords2(:,:)
 
-    !> xyz-component of G-function derivative for every neighboring atom
+    !! xyz-component of G-function derivative for every neighboring atom
     real(dp) :: gFuncGrad(3, size(neighDists1))
 
-    !> cutoff (derivative) values
+    !! cutoff (derivative) values
     real(dp) :: dfc_ik, dfc_jk, fc_ik, fc_jk
 
-    !> auxiliary variables
+    !! auxiliary variables
     real(dp) :: dist_jk, a_ijk, prefct_prod, T_ik(3, 3), uvec_jk(3), uvec_ik(3), tmpVec(3)
     real(dp), allocatable :: uvecs2(:,:), fc2(:), sqDists2(:)
     integer  :: jAtom, kAtom
@@ -1680,10 +1677,10 @@ contains
     !>
     real(dp), intent(in)  :: uvec(3), nrm
 
-    !>
+    !!
     real(dp) :: T_matr(3, 3)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer  :: ii, jj
 
     T_matr(:,:) = 0.0_dp
@@ -1712,7 +1709,7 @@ contains
     !> mpi communicator with some additional information
     type(mpifx_comm), intent(in) :: comm
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iFunc, dims0d
 
     call mpifx_bcast(comm, this%tZscore)
@@ -1768,19 +1765,19 @@ contains
     !> filename or path to write to
     character(len=*), intent(in) :: fname
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, mapping_id, func_id, precond_id
 
-    !> name of current G-function
+    !! name of current G-function
     character(len=:), allocatable :: funcname
 
-    !> number of symmetry mappings
+    !! number of symmetry mappings
     integer :: nFunctions
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer(size_t) :: dim
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iFunc, iErr, tmp, tExist
 
     ! open the hdf5 interface
@@ -1932,16 +1929,16 @@ contains
     !> number of radial and angular mappings
     integer, intent(out), optional :: nRadial, nAngular
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, mapping_id, func_id, precond_id
 
-    !> name of current G-function
+    !! name of current G-function
     character(len=:), allocatable :: funcname
 
-    !> temporary storage container
+    !! temporary storage container
     integer, allocatable :: acsfAtomicNumbers(:), tmpAtomicNumbers(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     character(len=100) :: tmpStr
     real(dp) :: tmpReal(1)
     real(dp), allocatable :: tmpRealArray1d(:)

--- a/prog/fortnet/lib_fortnet/initprogram.F90
+++ b/prog/fortnet/lib_fortnet/initprogram.F90
@@ -287,16 +287,16 @@ contains
     !> container of program variables
     type(TProgramVariables), intent(inout) :: this
 
-    !> input tree node pointers
+    !! input tree node pointers
     type(fnode), pointer :: root, hsdTree, tmp
 
-    !> string buffer instance
+    !! string buffer instance
     type(string) :: strBuffer
 
-    !> input version number
+    !! input version number
     integer :: inputVersion
 
-    !> true, if current mpi process is the lead
+    !! true, if current mpi process is the lead
     logical :: tLead
 
     ! make sure that allocatables are assigned
@@ -460,10 +460,10 @@ contains
     !> number of nodes per layer, including in- and output, expected shape: [nHiddenLayer + 2]
     integer, intent(in) :: allDims(:)
 
-    !> number of paramaters (weights + biases) per sub-nn
+    !! number of paramaters (weights + biases) per sub-nn
     integer :: nSubNnParams
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iLayer
 
     nSubNnParams = sum(allDims(2:))
@@ -484,13 +484,13 @@ contains
     !> node containig the information
     type(fnode), pointer :: node
 
-    !> string buffer instance
+    !! string buffer instance
     type(string) :: strBuffer
 
-    !> temporary random integer
+    !! temporary random integer
     integer :: tmpIntSeed
 
-    !> auxiliary variable
+    !! auxiliary variable
     real(dp) :: tmpRealSeed
 
     call getChildValue(node, 'ReadNetStats', option%tReadNetStats, .false.)
@@ -541,7 +541,7 @@ contains
     !> node containig the information
     type(fnode), pointer :: node, forcenode, tmp
 
-    !> string buffer instance
+    !! string buffer instance
     type(string) :: strBuffer
 
     if (associated(node)) then
@@ -592,13 +592,13 @@ contains
     !> mode of current run (train, validate, predict)
     character(len=*), intent(in) :: mode
 
-    !> string buffer instances
+    !! string buffer instances
     type(string) :: strBuffer
 
-    !> true, if files exist
+    !! true, if files exist
     logical :: tExist
 
-    !> true, if dataset holds corresponding information
+    !! true, if dataset holds corresponding information
     logical :: tStructures, tGlobalTargets, tAtomicTargets, tExtFeatures
 
     call getChildValue(node, 'NetstatFile', strBuffer, default='fortnet.hdf5')
@@ -677,10 +677,10 @@ contains
     !> number of input features and total training targets (global + atomic)
     integer, intent(in) :: nFeatures, nTargets
 
-    !> list of integers to parse hidden layer configuration
+    !! list of integers to parse hidden layer configuration
     type(TListInt) :: integerList
 
-    !> string buffer instance to parse type of transfer function
+    !! string buffer instance to parse type of transfer function
     type(string) :: strBuffer
 
     select case (tolower(case))
@@ -732,13 +732,13 @@ contains
     !> node containig the information
     type(fnode), intent(in), pointer :: node
 
-    !> node containing requested regularization
-    type(fnode), pointer :: regunode, tmp
-
     !> type of neural network
     character(len=*), intent(in) :: case
 
-    !> string buffer instances
+    !! node containing requested regularization
+    type(fnode), pointer :: regunode, tmp
+
+    !! string buffer instances
     type(string) :: strBuffer1, strBuffer2
 
     select case (tolower(case))
@@ -855,22 +855,22 @@ contains
     !> starting points, shape: [nPoints, nStrucs]
     real(dp), intent(in) :: initialGuess(:,:)
 
-    !> steepest descent optimizer
+    !! steepest descent optimizer
     type(TWrapSteepDesc), allocatable :: wrapSteepDesc(:)
 
-    !> conjugate gradients optimizer
+    !! conjugate gradients optimizer
     type(TWrapConjGrad), allocatable :: wrapConjGrad(:)
 
-    !> limited memory bfgs optimizer
+    !! limited memory bfgs optimizer
     type(TWrapLbfgs), allocatable :: wrapLbfgs(:)
 
-    !> fire optimizer
+    !! fire optimizer
     type(TWrapFire), allocatable :: wrapFire(:)
 
-    !> weights for steepest descent optimizer
+    !! weights for steepest descent optimizer
     real(dp), allocatable :: weights(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iStruc, nStrucs, nValues
 
     nValues = size(initialGuess, dim=1)
@@ -1012,23 +1012,23 @@ contains
     !> total number of external features in the dataset
     integer, intent(in) :: nTotExtFeatures
 
-    !> temporary storage for G-function parameters
+    !! temporary storage for G-function parameters
     character(len=:), allocatable :: type
     real(dp) :: rCut, kappa, rs, eta, lambda, xi
 
-    !> node containing the information
+    !! node containing the information
     type(fnode), pointer :: mappingnode, extnode, child, tmp, indChild
 
-    !> multiple nodes of same name
+    !! multiple nodes of same name
     type(fnodeList), pointer :: children
 
-    !> string buffer instance
+    !! string buffer instance
     type(string) :: strBuffer1, strBuffer2
 
-    !> functions emerging from an automatic generation scheme
+    !! functions emerging from an automatic generation scheme
     type(TGFunctions) :: autoFunctions, tmpFunctions
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iChild, iAutoBlock, nAutoBlocks, nRadial, nAngular, atomId
 
     call getChild(node, 'External', child=extnode, requested=.false.)
@@ -1209,13 +1209,13 @@ contains
     !> obtained number of radial and angular functions
     integer, intent(out) :: nRadial, nAngular
 
-    !> wrapper around multiple G-functions
+    !! wrapper around multiple G-functions
     type(TGFunctions) :: tmpGfunctions
 
-    !> combinations of atomic number pairs with replacement
+    !! combinations of atomic number pairs with replacement
     integer, allocatable :: comb(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iFunc, iAtNum, iComb, nSpecies, nFunctions
 
     ! count species-unresolved scheme
@@ -1379,13 +1379,13 @@ contains
   !> Prints date and time information to standard output.
   subroutine printDateAndTime()
 
-    !> Current date
+    !! Current date
     character(len=8) :: date
 
-    !> Current time
+    !! Current time
     character(len=10) :: time
 
-    !> Current time zone
+    !! Current time zone
     character(len=5) :: zone
 
     call date_and_time(date=date, time=time, zone=zone)

--- a/prog/fortnet/lib_hdf5fx/hdf5fx.F90
+++ b/prog/fortnet/lib_hdf5fx/hdf5fx.F90
@@ -60,7 +60,7 @@ contains
     !> representation of a dataset
     integer, intent(out), allocatable :: array(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer(size_t) :: type_size
     integer :: iErr, type_class
@@ -84,7 +84,7 @@ contains
     !> representation of a dataset
     integer, intent(out), allocatable :: array(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(2)
     integer(size_t) :: type_size
     integer :: iErr, type_class
@@ -108,7 +108,7 @@ contains
     !> representation of a dataset
     real(dp), intent(out), allocatable :: array(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer(size_t) :: type_size
     integer :: iErr, type_class
@@ -132,7 +132,7 @@ contains
     !> representation of a dataset
     real(dp), intent(out), allocatable :: array(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(2)
     integer(size_t) :: type_size
     integer :: iErr, type_class
@@ -156,7 +156,7 @@ contains
     !> representation of a dataset
     integer, intent(in) :: array(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer :: iErr
 
@@ -178,7 +178,7 @@ contains
     !> representation of a dataset
     integer, intent(in) :: array(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(2)
     integer :: iErr, iDim
 
@@ -203,7 +203,7 @@ contains
     !> representation of a dataset
     real(dp), intent(in) :: array(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer :: iErr
 
@@ -225,7 +225,7 @@ contains
     !> representation of a dataset
     real(dp), intent(in) :: array(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(2)
     integer :: iErr, iDim
 

--- a/prog/fortnet/lib_io/fnetdata.F90
+++ b/prog/fortnet/lib_io/fnetdata.F90
@@ -134,7 +134,7 @@ contains
     !> mpi communicator with some additional information
     type(mpifx_comm), intent(in) :: comm
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iData, dims0d
     integer, allocatable :: dims1d(:)
 
@@ -356,13 +356,13 @@ contains
     !> true, if the dataset provides structural information
     logical, intent(out) :: tStructures
 
-    !> file identification
+    !! file identification
     integer(hid_t) :: file_id
 
-    !> temporary storage container
+    !! temporary storage container
     integer :: tmp(1)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iErr
 
     ! open the hdf5 interface
@@ -405,13 +405,13 @@ contains
     !> optional output for the number of atomic targets
     integer, intent(out), optional :: nAtomicTargets
 
-    !> file identification
+    !! file identification
     integer(hid_t) :: file_id
 
-    !> temporary storage container
+    !! temporary storage container
     integer :: tmp(1)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr
 
     ! open the hdf5 interface
@@ -465,13 +465,13 @@ contains
     !> optional number of features per atom, provided by the dataset
     integer, intent(out), optional :: nFeatures
 
-    !> file identification
+    !! file identification
     integer(hid_t) :: file_id
 
-    !> temporary storage container
+    !! temporary storage container
     integer :: tmp(1)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr
 
     ! open the hdf5 interface
@@ -507,10 +507,10 @@ contains
     !> representation of a dataset
     type(TDataset), intent(in) :: ref, comp
 
-    !> logicals to determine if species exist in reference setchildvalue
+    !! logicals to determine if species exist in reference setchildvalue
     logical, allocatable :: tFound(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iSp1, iSp2
 
     if (.not. (ref%tTargets .eqv. comp%tTargets)) then
@@ -634,13 +634,13 @@ contains
     !> representation of acsf mapping information
     type(TAcsf), intent(in) :: acsf
 
-    !> true, if the ACSF configuration is fully species-unresolved
+    !! true, if the ACSF configuration is fully species-unresolved
     logical :: tReduce
 
-    !> temporary storage container
+    !! temporary storage container
     integer, allocatable :: datasetAtomicNumbers(:), acsfAtomicNumbers(:), tmpAtomicNumbers(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iFunc
 
     if (.not. dataset%tStructures) then
@@ -724,16 +724,16 @@ contains
     !> true, if the dataset is allowed to only hold a subset of BPNN species
     logical, intent(in), optional :: allowSpSubset
 
-    !> logicals to determine if species exist in reference setchildvalue
+    !! logicals to determine if species exist in reference setchildvalue
     logical, allocatable :: tFound(:)
 
-    !> if present, equals optional dummy argument, otherwise false
+    !! if present, equals optional dummy argument, otherwise false
     logical :: tAllowSpSubset
 
-    !> temporary storage container
+    !! temporary storage container
     integer, allocatable :: datasetAtomicNumbers(:), bpnnAtomicNumbers(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtNum1, iAtNum2
 
     if (present(allowSpSubset)) then
@@ -792,19 +792,19 @@ contains
     !> representation of a dataset
     type(TDataset), intent(out) :: dataset
 
-    !> file identification
+    !! file identification
     integer(hid_t) :: file_id, dataset_grp, training_grp, datapoint_grp, geometry_grp
 
-    !> temporary storage container
+    !! temporary storage container
     integer :: tmp(1)
 
-    !> determinant to calculate inverse lattice vectors
+    !! determinant to calculate inverse lattice vectors
     real(dp) :: det
 
-    !> name of current datapoint
+    !! name of current datapoint
     character(len=:), allocatable :: dname
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr, iDatapoint, tExist
 
     ! open the hdf5 interface
@@ -1027,7 +1027,7 @@ contains
     !> unique species name in order of local species indices
     character(mc), intent(out), allocatable :: speciesNames(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj, kk
     integer :: tmp1(size(localAtToAtNum)), tmp2(size(localAtToLocalSp))
     integer, allocatable :: uniqueAtNum(:), uniqueLocalSp(:)

--- a/prog/fortnet/lib_io/fnetout.F90
+++ b/prog/fortnet/lib_io/fnetout.F90
@@ -55,16 +55,16 @@ contains
     !> true, if writing out atomic forces is desired
     logical, intent(in) :: tForcesSupplied
 
-    !> file and group identification
+    !! file and group identification
     integer(hid_t) :: file_id, fnetout_id, output_id, datapoint_id
 
-    !> temporary storage container
+    !! temporary storage container
     real(dp), allocatable :: tmpOutput(:,:)
 
-    !> total number of training targets
+    !! total number of training targets
     integer :: nTargets
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer :: iSys, iErr
 

--- a/prog/fortnet/lib_io/iterout.F90
+++ b/prog/fortnet/lib_io/iterout.F90
@@ -38,16 +38,16 @@ contains
     !> gradient trajectory during training
     real(dp), intent(in), optional, target :: gradients(:)
 
-    !> pointer holding the available data
+    !! pointer holding the available data
     real(dp), pointer :: pData(:,:)
 
-    !> formatting of output file
+    !! formatting of output file
     character(len=:), allocatable :: fmt
 
-    !> unique fileunit
+    !! unique fileunit
     integer :: fd
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iLine, nLines, nColumns
 
     if (present(trainLoss)) then

--- a/prog/fortnet/lib_io/netstat.F90
+++ b/prog/fortnet/lib_io/netstat.F90
@@ -40,10 +40,10 @@ contains
     !> filename of netstat file
     character(len=*), intent(in) :: fname
 
-    !> file and group identification
+    !! file and group identification
     integer(hid_t) :: file_id, netstat_id
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iErr
 
     ! open the hdf5 interface
@@ -76,10 +76,10 @@ contains
     !> true, if ACSF mapping features are present
     logical, intent(out) :: tExtFeatures
 
-    !> file and group identifier
+    !! file and group identifier
     integer(hid_t) :: file_id, netstat_id, external_id
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr, tExist, tmp(1)
 
     ! open the hdf5 interface
@@ -131,10 +131,10 @@ contains
     !> true, if ACSF mapping features are present
     logical, intent(out) :: tAcsf
 
-    !> file and group identifier
+    !! file and group identifier
     integer(hid_t) :: file_id, netstat_id, mapping_id
 
-    !> auxiliary variables
+    !! auxiliary variables
     character(len=100) :: tmpStr
     integer :: iErr, tExist
 
@@ -187,10 +187,10 @@ contains
     !> variables of the External block read from a netstat file
     type(TExternalBlock), intent(out) :: ext
 
-    !> file and group identifier
+    !! file and group identifier
     integer(hid_t) :: file_id, netstat_id, external_id
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr, tExist, tmp(1)
 
     ! open the hdf5 interface
@@ -251,22 +251,22 @@ contains
     !> topology of the sub-nn's
     integer, intent(out), allocatable :: topology(:)
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, bpnn_id, subnet_id
 
-    !> atomic number of species
+    !! atomic number of species
     integer, allocatable :: atomicNumbers(:)
 
-    !> temporary network topology of current sub-nn
+    !! temporary network topology of current sub-nn
     integer, allocatable :: tmpTopology(:)
 
-    !> temporary type of activation functions of current sub-nn
+    !! temporary type of activation functions of current sub-nn
     character(len=:), allocatable :: tmpActivation
 
-    !> name of current subnetwork
+    !! name of current subnetwork
     character(len=:), allocatable :: netname
 
-    !> auxiliary variables
+    !! auxiliary variables
     character(len=100) :: tmp
     integer :: iErr, iNet
 
@@ -354,13 +354,13 @@ contains
     !> number of atomic targets of BPNN
     integer, intent(in) :: nAtomicTargets
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, bpnn_id, subnet_id, layer_id
 
-    !> name of current subnetwork and layer
+    !! name of current subnetwork and layer
     character(len=:), allocatable :: netname, layername
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dims(1)
     integer :: iErr, iNet, iLayer
 
@@ -448,10 +448,10 @@ contains
     !> data type containing variables of the External block
     type(TExternalBlock), intent(in) :: ext
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, external_id
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer(hsize_t) :: dim
     integer :: iErr, tExist
 

--- a/prog/fortnet/lib_nn/bpnn.F90
+++ b/prog/fortnet/lib_nn/bpnn.F90
@@ -121,7 +121,7 @@ contains
     !> type of activation function to use for all layers, except output layer (linear)
     character(len=*), intent(in), optional :: activation
 
-    !> Species identifier
+    !! Species identifier
     integer :: iSpecies
 
     this%dims = dims
@@ -209,28 +209,28 @@ contains
     !> optional, iteration-resolved total gradients
     real(dp), intent(out), allocatable, optional :: gradients(:)
 
-    !> network predictions during the training
+    !! network predictions during the training
     type(TPredicts) :: predicts, resPredicts, validPredicts
 
-    !> total weight and bias gradients of the current system
+    !! total weight and bias gradients of the current system
     type(TDerivs) :: dd, ddRes
 
-    !> temporary (validation) loss function container
+    !! temporary (validation) loss function container
     real(dp), allocatable :: tmpLoss(:), tmpValidLoss(:)
 
-    !> temporary iteration-resolved euclidean norm of total gradient
+    !! temporary iteration-resolved euclidean norm of total gradient
     real(dp), allocatable :: tmpGradients(:)
 
-    !> shuffle array to randomize the order of gradient calculations
+    !! shuffle array to randomize the order of gradient calculations
     integer, allocatable :: shuffle(:)
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     logical :: tPrintOut, tSaveNet
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, iIter, iStart, iEnd, iTmpIter, iLastIter
 
     call TDerivs_init(this%dims, size(this%nets), dd)
@@ -428,10 +428,10 @@ contains
     !> resulting network predictions
     type(TPredicts), intent(inout) :: resPredicts
 
-    !> temporary weight and bias gradient storage of the current atom
+    !! temporary weight and bias gradient storage of the current atom
     type(TDerivs) :: ddTmp
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, iSys, iGlobalSp, iLayer
 
     lpSystem: do ii = iStart, iEnd
@@ -493,7 +493,7 @@ contains
     !> mpi communicator with some additional information
     type(mpifx_comm), intent(in) :: comm
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iNet, iLayer, dims0d
     integer, allocatable :: tmpDims(:)
     character(len=1000) :: tmpStr
@@ -590,7 +590,7 @@ contains
     !> mpi communicator with some additional information
     type(mpifx_comm), intent(in) :: comm
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGlobalSp, iLayer
 
     do iGlobalSp = 1, size(this%nets)
@@ -637,28 +637,28 @@ contains
     !> shape: [nGlobalTargets + nAtomicTargets, nAtoms]
     real(dp), intent(out) :: predicts(:,:)
 
-    !> representation of temporary layer storage container
+    !! representation of temporary layer storage container
     type(TMultiLayerStruc) :: tmpLayer
 
-    !> temporary weight gradient storage of the current atom
+    !! temporary weight gradient storage of the current atom
     type(TWeightDerivs) :: dwTmp
 
-    !> temporary bias gradient storage of the current atom
+    !! temporary bias gradient storage of the current atom
     type(TBiasDerivs) :: dbTmp
 
-    !> loss gradients w.r.t predictions and targets (only system-wide targets)
+    !! loss gradients w.r.t predictions and targets (only system-wide targets)
     real(dp), allocatable :: globalLossGrad(:)
 
-    !> loss gradients w.r.t predictions and targets
+    !! loss gradients w.r.t predictions and targets
     real(dp), allocatable :: lossgrads(:,:)
 
-    !> temporary output storage of sub-nn's
+    !! temporary output storage of sub-nn's
     real(dp), allocatable :: tmpOut(:)
 
-    !> temporary real valued storage for summed up system-wide predictions
+    !! temporary real valued storage for summed up system-wide predictions
     real(dp), allocatable :: globalPredicts(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iAtom, iGlobalSp, iLayer
 
     call TMultiLayerStruc_init(this%dims, size(input, dim=2), tmpLayer)
@@ -734,16 +734,16 @@ contains
     !> true, if gradient got below the specified tolerance
     logical, intent(out) :: tConverged
 
-    !> serialized weights and biases
+    !! serialized weights and biases
     real(dp), allocatable :: weightsAndBiases(:,:), newWeightsAndBiases(:,:)
 
-    !> serialized weight and bias gradients
+    !! serialized weight and bias gradients
     real(dp), allocatable :: ddSerial(:,:)
 
-    !> sub-network resolved loss values
+    !! sub-network resolved loss values
     real(dp), allocatable :: subnetLoss(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iGlobalSp
 
     ! add loss based regularization, if desired
@@ -786,7 +786,7 @@ contains
     !> serialized weights and biases, shape: [nTotParams, nSpecies]
     real(dp), intent(in) :: weightsAndBiases(:,:)
 
-    !> Species identifier
+    !! Species identifier
     integer :: iGlobalSp
 
     do iGlobalSp = 1, this%nSpecies
@@ -805,10 +805,10 @@ contains
     !> serialized weights and biases
     real(dp), intent(out), allocatable :: weightsAndBiases(:,:)
 
-    !> temporary buffer
+    !! temporary buffer
     real(dp), allocatable :: buffer(:)
 
-    !> Species identifier
+    !! Species identifier
     integer :: iGlobalSp
 
     allocate(weightsAndBiases(this%nBiases + this%nWeights, this%nSpecies))
@@ -827,7 +827,7 @@ contains
     !> representation of a Behler-Parrinello neural network
     class(TBpnn), intent(inout) :: this
 
-    !> Species identifier
+    !! Species identifier
     integer :: iSpecies
 
     do iSpecies = 1, this%nSpecies
@@ -846,10 +846,10 @@ contains
     !> summed output of all sub-nn's
     real(dp), intent(out), allocatable :: output(:)
 
-    !> temporary store for output parts
+    !! temporary store for output parts
     real(dp), allocatable :: tmp(:)
 
-    !> Species identifier
+    !! Species identifier
     integer :: iSpecies
 
     allocate(output(this%dims(size(this%dims))))
@@ -874,16 +874,16 @@ contains
     !> index mapping local atom --> global species index
     integer, intent(in) :: localAtToGlobalSp(:)
 
-    !> atomic contributions to the network prediction
+    !! atomic contributions to the network prediction
     real(dp), allocatable :: atomicOutput(:,:)
 
-    !> number of predictions for each sub-nn
+    !! number of predictions for each sub-nn
     integer :: nOutput
 
-    !> number of atoms in the current system
+    !! number of atoms in the current system
     integer :: nAtoms
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtom, iGlobalSp
 
     nAtoms = size(input, dim=2)
@@ -911,13 +911,13 @@ contains
     !> index mapping local atom --> global species index
     integer, intent(in) :: localAtToGlobalSp(:)
 
-    !> derivatives of outputs w.r.t. atomic input features
+    !! derivatives of outputs w.r.t. atomic input features
     type(TJacobian) :: jacobian
 
-    !> number of atoms in the current system
+    !! number of atoms in the current system
     integer :: nAtoms
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iAtom, iGlobalSp
 
     nAtoms = size(input, dim=2)
@@ -947,13 +947,13 @@ contains
     !> index mapping local atom --> global species index
     type(TIntArray1D), intent(in) :: localAtToGlobalSp(:)
 
-    !> network predictions during the training
+    !! network predictions during the training
     type(TJacobians) :: jacobian, resJacobian
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iAtom, iStart, iEnd
 
   #:if WITH_MPI
@@ -1011,13 +1011,13 @@ contains
     !> index mapping local atom --> global species index
     type(TIntArray1D), intent(in) :: localAtToGlobalSp(:)
 
-    !> network predictions during the training
+    !! network predictions during the training
     type(TRealArray2D), allocatable :: predicts(:), resPredicts(:)
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iSys, iStart, iEnd
 
   #:if WITH_MPI
@@ -1066,13 +1066,13 @@ contains
     !> filename (will be fortnet.hdf5)
     character(len=*), intent(in) :: fname
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, bpnn_id, subnet_id, layer_id
 
-    !> name of current subnetwork and layer
+    !! name of current subnetwork and layer
     character(len=:), allocatable :: netname, layername
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr, iNet, iLayer, tExist
 
     ! open the hdf5 interface
@@ -1151,32 +1151,32 @@ contains
     !> filename (will be fortnet.hdf5)
     character(len=*), intent(in) :: fname
 
-    !> various specifier flags
+    !! various specifier flags
     integer(hid_t) :: file_id, netstat_id, bpnn_id, subnet_id, layer_id
 
-    !> name of current subnetwork and layer
+    !! name of current subnetwork and layer
     character(len=:), allocatable :: netname, layername
 
-    !> temporary activation function type
+    !! temporary activation function type
     character(len=:), allocatable :: activation, tmpActivation
 
-    !> dimensions of all layers in the sub-nn's
+    !! dimensions of all layers in the sub-nn's
     integer, allocatable :: dims(:), tmpDims(:)
 
-    !> atomic numbers of sub-nn species
+    !! atomic numbers of sub-nn species
     integer, allocatable :: atomicNumbers(:)
 
-    !> number of system-wide training targets of BPNN
+    !! number of system-wide training targets of BPNN
     integer :: nGlobalTargets
 
-    !> number of atomic training targets of BPNN
+    !! number of atomic training targets of BPNN
     integer :: nAtomicTargets
 
-    !> temporary storage container
+    !! temporary storage container
     integer :: tmpInt(1)
     character(len=100) :: tmpStr
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iErr, iNet, iLayer
 
     ! open the hdf5 interface

--- a/prog/fortnet/lib_nn/network.F90
+++ b/prog/fortnet/lib_nn/network.F90
@@ -103,7 +103,7 @@ contains
     !> luxury pseudorandom generator instance
     type(TRanlux), intent(inout), optional :: rndGen
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     this%dims = dims
@@ -128,7 +128,7 @@ contains
     !> representation of a neural network
     class(TNetwork), intent(inout) :: this
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iLayer
 
     this%nBiases = sum(this%dims)
@@ -157,10 +157,10 @@ contains
     !> outputs of current neural network instance
     real(dp), intent(out), allocatable, optional :: out(:)
 
-    !> temporary matrix * vector storage
+    !! temporary matrix * vector storage
     real(dp), allocatable :: tmpVec(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     this%layers(1)%aa = xx
@@ -188,19 +188,19 @@ contains
     !> input to feed network with
     real(dp), intent(in) :: xx(:)
 
-    !> forward derivatives, i.e. jacobian matrix w.r.t. input features
+    !! forward derivatives, i.e. jacobian matrix w.r.t. input features
     real(dp), allocatable :: jacobi(:,:)
 
-    !> activation and network input of neurons of current layer
+    !! activation and network input of neurons of current layer
     real(dp), allocatable :: aa(:), aarg(:)
 
-    !> transfer derivatives
+    !! transfer derivatives
     real(dp), allocatable :: deriv(:), diagDeriv(:,:)
 
-    !> temporary matrix * vector and matrix * matrix storage
+    !! temporary matrix * vector and matrix * matrix storage
     real(dp), allocatable :: tmpVec(:), tmpMat(:,:), tmpMat2(:,:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj
 
     aa = xx
@@ -259,13 +259,13 @@ contains
     !> bias gradients
     type(TBiasDerivs), intent(out) :: db
 
-    !> temporary matrix * vector storage
+    !! temporary matrix * vector storage
     real(dp), allocatable :: tmpVec(:)
 
-    !> number of arrays in the bias structure
+    !! number of arrays in the bias structure
     integer :: nArrays
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     call TWeightDerivs_init(this%dims, dw)
@@ -319,13 +319,13 @@ contains
     !> single sample of input data to calculate output for
     real(dp), intent(in) :: xx(:)
 
-    !> activation values
+    !! activation values
     real(dp), allocatable :: aa(:)
 
-    !> temporary matrix * vector storage
+    !! temporary matrix * vector storage
     real(dp), allocatable :: tmpVec(:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     allocate(tmpVec(size(transpose(this%layers(1)%ww), dim=1)))
@@ -356,10 +356,10 @@ contains
     !> batch of input data to calculate output for
     real(dp), intent(in) :: xx(:,:)
 
-    !> activation values
+    !! activation values
     real(dp), allocatable :: aa(:,:)
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     allocate(aa(this%dims(size(this%dims)), size(xx, dim=2)))
@@ -380,7 +380,7 @@ contains
     !> type of transfer function to use
     character(len=*), intent(in) :: descriptor
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iLayer
 
     do iLayer = 1, size(this%dims)
@@ -402,7 +402,7 @@ contains
     !> serialized weights and biases
     real(dp), intent(out), allocatable :: weightsAndBiases(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, iLayer, ind
 
     allocate(weightsAndBiases(this%nBiases + this%nWeights))
@@ -436,7 +436,7 @@ contains
     !> serialized weights and biases
     real(dp), intent(in) :: weightsAndBiases(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, iLayer, ind
 
     ind = 1
@@ -465,7 +465,7 @@ contains
     !> representation of a neural network
     class(TNetwork), intent(inout) :: this
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     do ii = 1, size(this%layers)

--- a/prog/fortnet/lib_nn/transfer.F90
+++ b/prog/fortnet/lib_nn/transfer.F90
@@ -56,7 +56,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = exp(- xx**2)
@@ -70,7 +70,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = - 2.0_dp * xx * gaussian(xx)
@@ -84,7 +84,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = log(1.0_dp + exp(xx))
@@ -98,7 +98,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 1.0_dp / (1.0_dp + exp(- xx))
@@ -112,7 +112,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = (sqrt(xx**2 + 1.0_dp) - 1.0_dp) / 2.0_dp + xx
@@ -126,7 +126,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = xx / (2.0_dp * sqrt(xx**2 + 1.0_dp)) + 1.0_dp
@@ -140,7 +140,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = max(0.0_dp, xx)
@@ -154,7 +154,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     where (xx >= 0.0_dp)
@@ -172,7 +172,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = max(0.01_dp * xx, xx)
@@ -186,7 +186,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     where (xx >= 0.0_dp)
@@ -204,7 +204,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 1.0_dp / (1.0_dp + exp(- xx))
@@ -218,7 +218,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = sigmoid(xx) * (1.0_dp - sigmoid(xx))
@@ -232,7 +232,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     where (xx > 0.0_dp)
@@ -250,7 +250,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 0.0_dp
@@ -264,7 +264,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = tanh(xx)
@@ -278,7 +278,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 1.0_dp - tanh(xx)**2
@@ -292,7 +292,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = atan(xx)
@@ -306,7 +306,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 1.0_dp / (xx**2 + 1.0_dp)
@@ -320,7 +320,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = xx
@@ -334,7 +334,7 @@ contains
     !> array to calculate the transfer function for
     real(dp), intent(in) :: xx(:)
 
-    !> corresponding transfer function values
+    !! corresponding transfer function values
     real(dp) :: res(size(xx))
 
     res(:) = 1.0_dp

--- a/prog/fortnet/lib_types/features.F90
+++ b/prog/fortnet/lib_types/features.F90
@@ -126,10 +126,10 @@ contains
     !> true, if validation monitoring is desired
     logical, intent(in) :: tMonitorValid
 
-    !> total number of input features
+    !! total number of input features
     integer :: nFeatures
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iData
 
     nFeatures = 0
@@ -207,7 +207,7 @@ contains
     !> true, if validation monitoring is desired
     logical, intent(in) :: tMonitorValid
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iData, nAcsf
 
     if (inpFeatures%tMappingFeatures) then
@@ -267,7 +267,7 @@ contains
     !> mpi communicator with some additional information
     type(mpifx_comm), intent(in) :: comm
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iData
 
     do iData = 1, size(this%trainFeatures)

--- a/prog/fortnet/lib_utils/intmanip.F90
+++ b/prog/fortnet/lib_utils/intmanip.F90
@@ -31,7 +31,7 @@ contains
     !> number of unique entries
     integer, intent(out), allocatable :: unique(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj, kk, tmp(size(array))
 
     kk = 1
@@ -61,7 +61,7 @@ contains
     !> number of unique entries
     integer, intent(out) :: nUnique
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj, tmp(size(array))
 
     nUnique = 1
@@ -92,13 +92,13 @@ contains
     !> container of all cominations obtained
     integer, intent(out), allocatable :: comb(:,:)
 
-    !> pool length to draw numbers from
+    !! pool length to draw numbers from
     integer :: nPool
 
-    !> expected number of combinations
+    !! expected number of combinations
     integer :: nComb
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: ii, jj, ind
     integer, allocatable :: indices(:)
 
@@ -148,10 +148,10 @@ contains
     !> integer to calculate the factorial for
     integer, intent(in) :: xx
 
-    !> resulting factorial
+    !! resulting factorial
     integer :: fact
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     if (xx < 0) then

--- a/prog/fortnet/prg_fnet/fortnet.F90
+++ b/prog/fortnet/prg_fnet/fortnet.F90
@@ -129,13 +129,13 @@ contains
     !> representation of ACSF mappings
     type(TAcsf), intent(out) :: trainAcsf
 
-    !> serialized initial weights and biases
+    !! serialized initial weights and biases
     real(dp), allocatable :: weightsAndBiases(:,:)
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> true, if an ACSF configuration is found in the netstat file
+    !! true, if an ACSF configuration is found in the netstat file
     logical :: tAcsf
 
   #:if WITH_MPI
@@ -285,7 +285,7 @@ contains
     !> number of atomic training targets of BPNN
     integer, intent(in) :: nAtomicTargets
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     write(stdout, '(A,/)') 'Sub-NN Details'
@@ -313,7 +313,7 @@ contains
     !> representation of feature information
     type(TFeaturesBlock), intent(in) :: features
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: iFunc
 
     if (features%tMappingFeatures) then
@@ -385,7 +385,7 @@ contains
     !> representation of feature information
     type(TFeaturesBlock), intent(in) :: features
 
-    !> auxiliary variable
+    !! auxiliary variable
     integer :: ii
 
     if (features%tExtFeatures) then
@@ -433,7 +433,7 @@ contains
     !> data type containing variables of the Regularization block
     type(TRegularizationBlock), intent(in) :: regu
 
-    !> string associated with the integer optimizer ID
+    !! string associated with the integer optimizer ID
     character(len=:), allocatable :: optimizerStr
 
     if (mode == 'train') then
@@ -520,16 +520,16 @@ contains
     !> representation of geometries with shifted atomic coordinates
     type(TGeometriesForFiniteDiff), intent(out) :: forcesGeos
 
-    !> serialized representation of geometries with shifted atomic coordinates
+    !! serialized representation of geometries with shifted atomic coordinates
     type(TGeometry), allocatable :: forcesSerializedGeos(:)
 
-    !> index mapping local atom --> atomic number
+    !! index mapping local atom --> atomic number
     type(TIntArray1D), allocatable :: localAtToAtNum(:)
 
-    !> atom dependent scaling parameters for cutoff function
+    !! atom dependent scaling parameters for cutoff function
     type(TRealArray2D), allocatable :: extFeatures(:)
 
-    !> auxiliary variables
+    !! auxiliary variables
     integer :: iGeo, ii, nTotGeometries, ind
 
     write(stdOut, '(A)', advance='no') 'Calculating ACSF...'
@@ -604,28 +604,28 @@ contains
     !> obtained atomic forces
     type(TForces), intent(out) :: forces
 
-    !> true, if gradient got below the specified tolerance
+    !! true, if gradient got below the specified tolerance
     logical :: tConverged
 
-    !> true, if current process is the lead
+    !! true, if current process is the lead
     logical :: tLead
 
-    !> iteration of lowest training/validation loss
+    !! iteration of lowest training/validation loss
     integer :: iMin, iValidMin
 
-    !> training/validation loss obtained during training
+    !! training/validation loss obtained during training
     real(dp), allocatable :: trainLoss(:), validLoss(:)
 
-    !> training gradients obtained during training
+    !! training gradients obtained during training
     real(dp), allocatable :: gradients(:)
 
-    !> summed loss of predictions, in comparison to targets
+    !! summed loss of predictions, in comparison to targets
     real(dp) :: mse, rms, mae
 
-    !> min. and max. deviation of predictions, in comparison to targets
+    !! min. and max. deviation of predictions, in comparison to targets
     real(dp) :: min, max
 
-    !> contains Jacobians of multiple systems
+    !! contains Jacobians of multiple systems
     type(TJacobians) :: jacobian
 
   #:if WITH_MPI


### PR DESCRIPTION
Removes docmarkers for variables that aren't part of the function signature. Otherwise Ford will create incorrect API docs.